### PR TITLE
Update GTP header to stretch seq# to 4B

### DIFF
--- a/core/utils/gtp.h
+++ b/core/utils/gtp.h
@@ -24,8 +24,8 @@ namespace utils {
 			const uint8_t *pktptr = (const uint8_t *)this;
 			size_t len = sizeof(Gtpv1);
 
-			if (gtph->seq)
-				len += 2;
+			if (gtph->seq)			/* TODO: Sequence # len set to 4B; verify this! */
+				len += 4;		/* See section 9.3 of 3GPP TS 29.060 (Release 13) */
 			if (gtph->pdn)
 				len += 1;
 			if (gtph->ex) {


### PR DESCRIPTION
Spirent packet emulator appends a 4-byte Seq# in GTPv1 header. Need to verify this further. OMEC's DP also has a 4-byte seq# field.

Signed-off-by: Muhammad Asim Jamshed <muhammad.jamshed@intel.com>