### PR TITLE
Remove gtp_common.h soft link file as it is not needed.

### DIFF
--- a/cpiface/gtp_common.h
+++ b/cpiface/gtp_common.h
@@ -1,1 +1,0 @@
-../core/utils/gtp_common.h


### PR DESCRIPTION
Dockerfile currently handles include path logic.

Signed-off-by: Muhammad Asim Jamshed <muhammad.jamshed@intel.com>