### PR TITLE
Topics/ipfrag: Adding IPv4 fragmentation support.

### DIFF
--- a/conf/route_control.py
+++ b/conf/route_control.py
@@ -103,7 +103,7 @@ def link_route_module(server, gateway_mac, item):
     iprange = item.iprange
     prefix_len = item.prefix_len
     route_module = item.iface + 'Routes'
-    last_module = item.iface + 'FastPO'
+    last_module = item.iface + 'Merge'
     gateway_mac_str = '{:X}'.format(gateway_mac)
     print('Adding route entry {}/{} for {}'.format(iprange, prefix_len,
                                                    route_module))
@@ -221,7 +221,7 @@ def del_route_entry(server, item):
     iprange = item.iprange
     prefix_len = item.prefix_len
     route_module = item.iface + 'Routes'
-    last_module = item.iface + 'FastPO'
+    last_module = item.iface + 'Merge'
 
     neighbor_exists = neighborcache.get(item.neighbor_ip)
     if neighbor_exists:
@@ -341,7 +341,7 @@ def parse_new_route(msg):
         probe_addr(item, ipdb.interfaces[item.iface].address)
 
     else:  # if gateway_mac is set
-        print('Linking module {}Routes with {}FastPO (Dest MAC: {})'.format(
+        print('Linking module {}Routes with {}Merge (Dest MAC: {})'.format(
             item.iface, item.iface, _mac))
 
         link_route_module(bess, gateway_mac, item)
@@ -358,7 +358,7 @@ def parse_new_neighbor(msg):
 
     item = arpcache.get(neighbor_ip)
     if item:
-        print('Linking module {}Routes with {}FastPO (Dest MAC: {})'.format(
+        print('Linking module {}Routes with {}Merge (Dest MAC: {})'.format(
             item.iface, item.iface, gateway_mac))
 
         # Add route entry, and add item in the registered neighbor cache

--- a/conf/spgwu.bess
+++ b/conf/spgwu.bess
@@ -96,12 +96,7 @@ class Port:
         self.bpf.clear()
 
         # Default drop when no matches
-        if max_ip_defrag_flows is not None:
-            ipdefrag = __bess_module__("{}Defrag".format(name), 'IPDefrag', num_flows=max_ip_defrag_flows, numa=0)
-            self.fpi -> ipdefrag:1 -> self.bpf:0 -> Sink()
-            ipdefrag:0 -> Sink()
-        else:
-            self.fpi -> self.bpf:0 -> Sink()
+        self.fpi -> self.bpf:0 -> Sink()
 
         # Initialize route module
         self.rtr = __bess_module__("{}Routes".format(name), 'IPLookup')
@@ -171,6 +166,12 @@ class Port:
 
                 # Direct control traffic from kernel to DPDK
                 spi -> self.fpo
+
+                # Direct fast path traffic to Frag module
+                merge = __bess_module__("{}Merge".format(name), 'Merge')
+                frag = __bess_module__("{}IP4Frag".format(name), 'IPFrag')
+                merge -> frag:1 -> self.fpo
+                frag:0 -> Sink()
 
                 tc = 'slow{}'.format(wid)
                 try:
@@ -260,7 +261,7 @@ ue_filter = {"priority": -UEGate,
              "filter": "ip dst net {}".format(ue_cidr), "gate": UEGate}
 sgiFastBPF.add(filters=[ue_filter])
 
-sgiFastBPF:UEGate \
+sgiFastBPF:UEGate -> sgiIP4Defrag::IPDefrag(num_flows=max_ip_defrag_flows, numa=0):1 \
     -> EtherTrim::GenericDecap(bytes=14) \
     -> GTPUEncap::GtpuEncap(s1u_sgw_ip=ip2long(ips_by_interface(s1u_ifname)[0]), num_subscribers=max_sessions):1 \
     -> S1UEtherAdd::GenericEncap(fields=[
@@ -273,7 +274,7 @@ sgiFastBPF:UEGate \
 
 # Drop unknown packets
 GTPUEncap:0 -> Sink()
-
+sgiIP4Defrag:0 -> Sink()
 
 # ====================================================
 #       Uplink Pipeline
@@ -307,7 +308,8 @@ s1uFastBPF.add(filters=[uplink_filter])
 
 sgiRoutes = ports[sgi_ifname].rtr
 
-s1uFastBPF:GTPUGate -> EtherDecapTrim::GenericDecap(bytes=14) -> GTPUDecap::GtpuDecap(ename="GTPUEncap"):1 \
+s1uFastBPF:GTPUGate -> s1uIP4Defrag::IPDefrag(num_flows=max_ip_defrag_flows, numa=0):1 \
+    -> EtherDecapTrim::GenericDecap(bytes=14) -> GTPUDecap::GtpuDecap(ename="GTPUEncap"):1 \
     -> SGIEtherAdd::GenericEncap(fields=[
         {'size': 6, 'value': {'value_int': 0x0}},
         {'size': 6, 'value': {'value_int': mac2hex(mac_by_interface(sgi_ifname))}},
@@ -322,7 +324,7 @@ s1uFastBPF:GTPUEchoGate \
 # Drop unknown packets
 GTPUEcho:0 -> Sink()
 GTPUDecap:0 -> Sink()
-
+s1uIP4Defrag:0 -> Sink()
 
 # ====================================================
 #       SIM_TEST

--- a/conf/spgwu.json
+++ b/conf/spgwu.json
@@ -8,8 +8,8 @@
     "": "max UE sessions",
     "max_sessions": 50000,
 
-    "": "max IP frag table entries. Update the line below to `\"max_ip_defrag_flows\": 5000` to enable",
-    "": "max_ip_defrag_flows: 5000",
+    "": "max IP frag table entries (for IPv4 reassembly)",
+    "max_ip_defrag_flows": 1000,
 
     "": "Gateway interfaces",    
     "s1u": {

--- a/core/modules/ip_defrag.cc
+++ b/core/modules/ip_defrag.cc
@@ -103,9 +103,6 @@ CommandResponse IPDefrag::Init(const bess::pb::IPDefragArg &arg) {
 
   numa = arg.numa();
 
-  if (numa < 0)
-    return CommandFailure(EINVAL, "Invalid value for NUMA id!");
-
   defrag_cycles = (rte_get_tsc_hz() + MS_PER_S - 1) / MS_PER_S * num_flows;
 
   cur_tsc = 0;

--- a/core/modules/ip_frag.cc
+++ b/core/modules/ip_frag.cc
@@ -1,0 +1,163 @@
+/* for ip_frag decls */
+#include "ip_frag.h"
+/* for rte_zmalloc() */
+#include <rte_malloc.h>
+/* for RTE_ETHER macros */
+#include "rte_ether.h"
+/* for be32_t */
+#include "utils/endian.h"
+/* for ToIpv4Address() */
+#include "utils/ip.h"
+/* for eth header */
+#include "utils/ether.h"
+/*----------------------------------------------------------------------------------*/
+using bess::utils::Ethernet;
+using bess::utils::Ipv4;
+using bess::utils::be32_t;
+using bess::utils::be16_t;
+using bess::utils::ToIpv4Address;
+
+enum {DEFAULT_GATE = 0, FORWARD_GATE};
+/*----------------------------------------------------------------------------------*/
+/**
+ * Returns NULL if packet is fragmented and needs more for reassembly.
+ * Returns Packet ptr if the packet is unfragmented, or is freshly reassembled.
+ */
+bess::Packet *
+IPFrag::FragmentPkt(Context *ctx, bess::Packet *p)
+{
+	struct rte_ether_hdr *ethh = (struct rte_ether_hdr *)(p->head_data<Ethernet *>());
+	struct rte_ipv4_hdr *iph = (struct rte_ipv4_hdr *)((unsigned char *)ethh + sizeof(struct rte_ether_hdr));
+	struct rte_mbuf *m = (struct rte_mbuf *)p;
+
+	if (RTE_ETH_IS_IPV4_HDR(m->packet_type) &&
+	    unlikely((RTE_ETHER_MAX_LEN - RTE_ETHER_CRC_LEN) < p->total_len())) {
+		volatile int32_t res;
+		struct rte_ether_hdr ethh_copy;
+		int32_t j;
+		struct rte_mbuf *frag_tbl[BATCH_SIZE];
+		unsigned char *orig_ip_payload;
+		uint16_t orig_data_offset;
+
+		/* retrieve Ethernet header */
+		rte_memcpy(&ethh_copy, ethh, sizeof(struct rte_ether_hdr));
+
+		/* remove the Ethernet header and trailer from the input packet */
+		rte_pktmbuf_adj(m, (uint16_t)sizeof(struct rte_ether_hdr));
+
+		/* retrieve orig ip payload for later re-use in ip frags */
+		orig_ip_payload =
+			rte_pktmbuf_mtod_offset(m, unsigned char *, sizeof(struct rte_ipv4_hdr));
+		orig_data_offset = 0;
+
+		/* fragment the IPV4 packet */
+		res = rte_ipv4_fragment_packet(m,
+					       &frag_tbl[0],
+					       BATCH_SIZE,
+					       RTE_ETHER_MAX_LEN - RTE_ETHER_CRC_LEN - RTE_ETHER_HDR_LEN,
+					       m->pool,
+					       indirect_pktmbuf_pool->pool());
+
+		if (unlikely(res < 0)) {
+			EmitPacket(ctx, p, DEFAULT_GATE);
+			return NULL;
+		} else {
+			/* now copy the Ethernet header + IP payload to each frag */
+			for (j = 0; j < res; j++) {
+				m = frag_tbl[j];
+				ethh = (struct rte_ether_hdr *)
+					rte_pktmbuf_prepend(m, (uint16_t)sizeof(struct rte_ether_hdr));
+				if (ethh == NULL)
+					rte_panic("No headroom in mbuf.\n");
+				/* remove chained mbufs (as they are not needed) */
+				struct rte_mbuf *del_mbuf = m->next;
+				while (del_mbuf != NULL) {
+					rte_pktmbuf_free_seg(del_mbuf);
+					del_mbuf = del_mbuf->next;
+				}
+
+				/* setting mbuf metadata */
+				m->l2_len = sizeof(struct rte_ether_hdr);
+				m->data_len = m->pkt_len;
+				m->nb_segs = 1;
+				m->next = NULL;
+				rte_memcpy(ethh, &ethh_copy, sizeof(struct rte_ether_hdr));
+
+				ethh = (struct rte_ether_hdr *)rte_pktmbuf_mtod(m, struct rte_ether_hdr *);
+				iph = (struct rte_ipv4_hdr *)(ethh + 1);
+
+				/* copy ip payload */
+				unsigned char *ip_payload = (unsigned char *)((unsigned char *)iph +
+									      ((iph->version_ihl & RTE_IPV4_HDR_IHL_MASK) << 2));
+				uint16_t ip_payload_len = m->pkt_len - sizeof(struct rte_ether_hdr) -
+					((iph->version_ihl & RTE_IPV4_HDR_IHL_MASK) << 2);
+
+				/* if total frame size is less than minimum transmission unit, add IP padding */
+				if (unlikely(ip_payload_len + sizeof(struct rte_ipv4_hdr) +
+					     sizeof(struct rte_ether_hdr) + RTE_ETHER_CRC_LEN < RTE_ETHER_MIN_LEN)) {
+					/* update ip->ihl first */
+					iph->version_ihl &= 0xF0;
+					iph->version_ihl |= (RTE_IPV4_HDR_IHL_MASK & (PADDED_IPV4_HDR_SIZE>>2));
+					/* update ip->tot_len */
+					iph->total_length = ntohs(ip_payload_len + PADDED_IPV4_HDR_SIZE);
+					/* update l3_len */
+					m->l3_len = PADDED_IPV4_HDR_SIZE;
+					/* update data_len & pkt_len */
+					m->data_len = m->pkt_len = m->pkt_len + IP_PADDING_LEN;
+					/* ip_payload is currently the place you would add 0s */
+					memset(ip_payload, 0, IP_PADDING_LEN);
+
+					/* re-set ip_payload to the right `offset` (location) now */
+					ip_payload += IP_PADDING_LEN;
+				}
+				rte_memcpy(ip_payload,
+					   orig_ip_payload + orig_data_offset,
+					   ip_payload_len);
+				orig_data_offset += ip_payload_len;
+				iph->hdr_checksum = 0;
+				iph->hdr_checksum = rte_ipv4_cksum((struct rte_ipv4_hdr*)iph);
+			}
+			for (int i = 0; i < res; i++)
+				EmitPacket(ctx, (bess::Packet *)frag_tbl[i], FORWARD_GATE);
+
+			/* all fragments successfully forwarded. Return NULL */
+			return NULL;
+		}
+	}
+
+	return p;
+}
+/*----------------------------------------------------------------------------------*/
+void
+IPFrag::ProcessBatch(Context *ctx, bess::PacketBatch *batch)
+{
+	int cnt = batch->cnt();
+	for (int i = 0; i < cnt; i++) {
+		bess::Packet *p = batch->pkts()[i];
+		p = FragmentPkt(ctx, p);
+		if (p) EmitPacket(ctx, p, FORWARD_GATE);
+	}
+}
+/*----------------------------------------------------------------------------------*/
+void
+IPFrag::DeInit()
+{
+	if (indirect_pktmbuf_pool != NULL) {
+		/* free allocated IP frags */
+		delete indirect_pktmbuf_pool;
+		indirect_pktmbuf_pool = NULL;
+	}
+}
+/*----------------------------------------------------------------------------------*/
+CommandResponse
+IPFrag::Init(const bess::pb::EmptyArg &) {
+
+	std::string pool_name = this->name() + "_indirect_mbuf_pool";
+
+	indirect_pktmbuf_pool = new bess::DpdkPacketPool();
+	if (indirect_pktmbuf_pool == NULL)
+		return CommandFailure(ENOMEM, "Cannot create indirect mempool!");
+	return CommandSuccess();
+}
+/*----------------------------------------------------------------------------------*/
+ADD_MODULE(IPFrag, "ip_frag", "IPv4 Fragmentation module")

--- a/core/modules/ip_frag.h
+++ b/core/modules/ip_frag.h
@@ -1,0 +1,60 @@
+#ifndef BESS_MODULES_IPFRAG_H_
+#define BESS_MODULES_IPFRAG_H_
+/*----------------------------------------------------------------------------------*/
+#include <rte_cycles.h>
+#include <rte_ip_frag.h>
+/* for ipv4 header */
+#include <rte_ip.h>
+#include "../module.h"
+#include "../pb/module_msg.pb.h"
+/*----------------------------------------------------------------------------------*/
+/**
+ * RX_NUM_DESC < 1024:
+ * But increased sensivity kernel packet processing core sched jitters
+ */
+#define RX_NUM_DESC             2048
+
+/**
+ * macro to config tx ring size.
+ */
+#define TX_NUM_DESC             RX_NUM_DESC
+
+/**
+ * macro to set the batch size
+ */
+#define BATCH_SIZE		64
+
+/**
+ * DPDK default value optimial.
+ */
+#define MBUF_CACHE_SIZE		512
+
+#define IP_PADDING_LEN          28
+#define PADDED_IPV4_HDR_SIZE    (sizeof(struct rte_ipv4_hdr) + IP_PADDING_LEN)
+/**
+ * NUM_MBUFS >= 2x RX_NUM_DESC::
+ *              Else rte_eth_dev_start(...) { FAIL; ...}
+ *      NUM_MBUFS >= 1.5x MBUF_CACHE_SIZE::
+ *              Else rte_pktmbuf_pool_create(...) { FAIL; ...}
+ */
+#define NUM_MBUFS (TX_NUM_DESC*2) > (1.5*MBUF_CACHE_SIZE) ? (TX_NUM_DESC*2) : (2*MBUF_CACHE_SIZE)
+/*----------------------------------------------------------------------------------*/
+class IPFrag final : public Module {
+ public:
+	IPFrag() {
+		max_allowed_workers_ = Worker::kMaxWorkers;
+	}
+
+	/* Gates: (0) Default, (1) Forward */
+	static const gate_idx_t kNumOGates = 2;
+
+	CommandResponse Init(const bess::pb::EmptyArg &arg);
+	void DeInit() override;
+	void ProcessBatch(Context *ctx, bess::PacketBatch *batch) override;
+
+ private:
+	bess::Packet *FragmentPkt(Context *ctx, bess::Packet *p);
+	bess::DpdkPacketPool *indirect_pktmbuf_pool = NULL;
+};
+/*----------------------------------------------------------------------------------*/
+#endif  // BESS_MODULES_IPFRAG_H_


### PR DESCRIPTION
This PR enables IPv4 fragmentation support. It also makes IPv4 reassembly support enabled by default. Both the modules are ready for external testing.