### PR TITLE
Use PCI addr in veth alias, fallback to scanning

### DIFF
--- a/conf/spgwu.bess
+++ b/conf/spgwu.bess
@@ -135,16 +135,29 @@ class Port:
                 self.init_fastpath(**kwargs)
 
         elif mode == 'dpdk':
-            # if port list is empty, scan for dpdk_ports first
-            if not dpdk_ports and scan_dpdk_ports() == False:
-                print('Registered dpdk ports do not exist.')
-                sys.exit()
-            # Initialize DPDK fastpath
-            fidx = dpdk_ports.get(mac_by_interface(name))
-            if fidx is None:
-                raise Exception('Registered port for {} not detected!'.format(name))
-            kwargs = {"port_id" : fidx, "num_out_q": workers}
-            self.init_fastpath( **kwargs)
+            kwargs = None
+            pci = alias_by_interface(name)
+            if pci is not None:
+                kwargs = {"pci": pci, "num_out_q": workers}
+                try:
+                    self.init_fastpath(**kwargs)
+                except:
+                    kwargs = None
+                    print('Unable to initialize {} fastpath using alias {},\
+                        falling back to scan'.format(name, pci))
+            if kwargs is None:
+                # Fallback to scanning ports
+                # if port list is empty, scan for dpdk_ports first
+                if not dpdk_ports and scan_dpdk_ports() == False:
+                    print('Registered dpdk ports do not exist.')
+                    sys.exit()
+                # Initialize DPDK fastpath
+                fidx = dpdk_ports.get(mac_by_interface(name))
+                if fidx is None:
+                    raise Exception(
+                        'Registered port for {} not detected!'.format(name))
+                kwargs = {"port_id": fidx, "num_out_q": workers}
+                self.init_fastpath(**kwargs)
 
             # Initialize kernel slowpath port and RX/TX modules
             try:

--- a/conf/utils.py
+++ b/conf/utils.py
@@ -32,6 +32,7 @@ def getpythonpid(process_name):
             return proc.info['pid']
     return
 
+
 def get_json_conf(path, dump):
     conf = json.loads(open(path).read())
     if dump:
@@ -53,6 +54,11 @@ def get_env(varname, default=None):
 def ips_by_interface(name):
     ipdb = IPDB()
     return [ipobj[0] for ipobj in ipdb.interfaces[name]['ipaddr'].ipv4]
+
+
+def alias_by_interface(name):
+    ipdb = IPDB()
+    return ipdb.interfaces[name]['ifalias']
 
 
 def mac_by_interface(name):


### PR DESCRIPTION
This will be primarily for k8s setup. To test locally

```
docker exec bess ip link set ens803f2 alias '0000:07:02.0'
docker exec bess ip link set ens803f3 alias '0000:07:02.1'
docker exec bess ./bessctl run spgwu
```

Signed-off-by: Saikrishna Edupuganti <saikrishna.edupuganti@intel.com>