### PR TITLE
routectl Allow bootstrap current routes on restart

### DIFF
--- a/conf/route_control.py
+++ b/conf/route_control.py
@@ -483,7 +483,7 @@ def main():
     connect_bessd()
 
     # program current routes
-    #bootstrap_routes()
+    bootstrap_routes()
 
     # listen for netlink events
     print('Registering netlink event listener callback...'),


### PR DESCRIPTION
In case the routectl crashes and comes back up after pipeline has been programmed then it should bootstrap using existing routes.