### PR TITLE
Minimize  what we copy to cpiface stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -129,6 +129,8 @@ COPY core/utils/gtp_common.h /cpiface
 RUN cd /cpiface && \
     make $MAKEFLAGS PBDIR=/protobuf && \
     cp zmq-cpiface /bin/
+RUN mkdir -p /grpc-libs && \
+    cp /opt/grpc/libs/opt/libgrpc.so /opt/grpc/libs/opt/libgrpc++.* /grpc-libs
 
 # Stage cpiface: creates runtime image of cpiface
 FROM ubuntu:18.04 as cpiface
@@ -138,7 +140,7 @@ RUN apt-get update && \
         libzmq5 && \
     rm -rf /var/lib/apt/lists/*
 
-COPY --from=cpiface-build /opt/grpc/libs/opt /opt/grpc/libs/opt
-RUN echo "/opt/grpc/libs/opt" > /etc/ld.so.conf.d/grpc.conf && \
+COPY --from=cpiface-build /grpc-libs /grpc-libs
+RUN echo "/grpc-libs" > /etc/ld.so.conf.d/grpc.conf && \
     ldconfig
 COPY --from=cpiface-build /bin/zmq-cpiface /bin


### PR DESCRIPTION
Docker build stage seems to complete once we reduce libraries being copied to cpiface stage

```
#29 [cpiface 3/5] COPY --from=cpiface-build /opt/grpc/libs/opt /opt/grpc/lib...
#29 ERROR: failed to copy files: userspace copy failed: write /var/lib/docker/overlay2/c6480ij2vovmd28msmoo9b747/merged/opt/grpc/libs/opt/libgrpc_cronet.a: no space left on device
------
 > [cpiface 3/5] COPY --from=cpiface-build /opt/grpc/libs/opt /opt/grpc/libs/opt:
------
failed to solve with frontend dockerfile.v0: failed to build LLB: failed to copy files: userspace copy failed: write /var/lib/docker/overlay2/c6480ij2vovmd28msmoo9b747/merged/opt/grpc/libs/opt/libgrpc_cronet.a: no space left on device
##[error]Process completed with exit code 1.
```
https://github.com/omec-project/upf-epc/runs/650917611?check_suite_focus=true#step:3:6434
vs

```
#29 [cpiface-build 8/8] RUN mkdir -p /grpc-libs &&     cp /opt/grpc/libs/opt...
#29 DONE 1.6s

#30 [cpiface 3/5] COPY --from=cpiface-build /grpc-libs /grpc-libs
#30 DONE 1.3s

#31 [cpiface 4/5] RUN echo "/grpc-libs" > /etc/ld.so.conf.d/grpc.conf &&    ...
#31 0.215 /sbin/ldconfig.real: /grpc-libs/libgrpc++.so.1 is not a symbolic link
#31 0.215 
#31 DONE 0.3s
```
https://github.com/omec-project/upf-epc/runs/651164999?check_suite_focus=true#step:3:6403