### PR TITLE
Minimize capabilities, emulate k8s env closely with pause

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,8 @@ RUN git clone -b $DPDK_VER -q --depth 1 $DPDK_URL $DPDK_DIR
 
 # Customizing DPDK install
 WORKDIR $DPDK_DIR
+COPY patches/dpdk patches
+RUN cat patches/* | patch -p1
 
 ARG CPU=native
 ARG RTE_TARGET='x86_64-native-linuxapp-gcc'

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,8 @@ docker-build:
 			--build-arg org_label_schema_vcs_ref="${DOCKER_LABEL_VCS_REF}" \
 			--build-arg org_label_schema_build_date="${DOCKER_LABEL_BUILD_DATE}" \
 			--build-arg org_opencord_vcs_commit_date="${DOCKER_LABEL_COMMIT_DATE}" \
-			.; \
+			. \
+			|| exit 1; \
 	done
 
 docker-push:

--- a/docker_setup.sh
+++ b/docker_setup.sh
@@ -85,6 +85,7 @@ function setup_mirror_links() {
 function move_ifaces() {
 	for ((i = 0; i < num_ifaces; i++)); do
 		sudo ip link set "${ifaces[$i]}" netns pause up
+		sudo ip netns exec pause ip link set "${ifaces[$i]}" promisc off
 	done
 	setup_addrs
 }
@@ -105,7 +106,7 @@ elif [ "$mode" == 'af_xdp' ]; then
 	PRIVS='--privileged'
 
 elif [ "$mode" == 'af_packet' ]; then
-	PRIVS='--cap-add IPC_LOCK --cap-add NET_ADMIN'
+	PRIVS='--cap-add IPC_LOCK'
 
 fi
 

--- a/patches/bess/0006-Add-switch-for-promiscuous-mode.patch
+++ b/patches/bess/0006-Add-switch-for-promiscuous-mode.patch
@@ -1,0 +1,46 @@
+From 260ef6f9bef9cce1a1c171e9da7b6ba854e9f994 Mon Sep 17 00:00:00 2001
+From: Saikrishna Edupuganti <saikrishna.edupuganti@intel.com>
+Date: Fri, 12 Jun 2020 00:11:50 +0000
+Subject: [PATCH] Add switch for promiscuous mode
+
+Set promiscuous only if explicitly asked by user
+
+Signed-off-by: Saikrishna Edupuganti <saikrishna.edupuganti@intel.com>
+---
+ core/drivers/pmd.cc           | 7 ++++++-
+ protobuf/ports/port_msg.proto | 1 +
+ 2 files changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/core/drivers/pmd.cc b/core/drivers/pmd.cc
+index a3cbf1fd..733b50ec 100644
+--- a/core/drivers/pmd.cc
++++ b/core/drivers/pmd.cc
+@@ -313,7 +313,12 @@ CommandResponse PMDPort::Init(const bess::pb::PMDPortArg &arg) {
+     }
+   }
+
+-  rte_eth_promiscuous_enable(ret_port_id);
++  if (arg.promiscuous_mode()) {
++    ret = rte_eth_promiscuous_enable(ret_port_id);
++    if (ret != 0) {
++      return CommandFailure(-ret, "rte_eth_promiscuous_enable() failed");
++    }
++  }
+
+   int offload_mask = 0;
+   offload_mask |= arg.vlan_offload_rx_strip() ? ETH_VLAN_STRIP_OFFLOAD : 0;
+diff --git a/protobuf/ports/port_msg.proto b/protobuf/ports/port_msg.proto
+index 1e8b6af8..853380e1 100644
+--- a/protobuf/ports/port_msg.proto
++++ b/protobuf/ports/port_msg.proto
+@@ -50,6 +50,7 @@ message PMDPortArg {
+   oneof socket {
+     int32 socket_id = 8;
+   }
++  bool promiscuous_mode = 9;
+ }
+
+ message UnixSocketPortArg {
+--
+2.25.1
+

--- a/patches/dpdk/0001-af_packet-Avoid-set-ioctl-if-there-is-no-flag-diff.patch
+++ b/patches/dpdk/0001-af_packet-Avoid-set-ioctl-if-there-is-no-flag-diff.patch
@@ -1,0 +1,52 @@
+From e1bc63488d346cb84ae7e76f2bc480247f577abb Mon Sep 17 00:00:00 2001
+From: Saikrishna Edupuganti <saikrishna.edupuganti@intel.com>
+Date: Fri, 12 Jun 2020 21:36:53 +0000
+Subject: [PATCH] af_packet Avoid set ioctl if there is no flag diff
+
+rte_eth_dev_start -> rte_eth_dev_config_restore
+In 19.11 DPDK started returning errors
+https://github.com/DPDK/dpdk/commit/9039c8125730adfd46b8c891e7f205eb4ac43c67
+https://github.com/DPDK/dpdk/commit/69d0e7092874db1909bc40986c06219f1880dc23
+
+Gist
+https://gist.github.com/krsna1729/0c7160920343f9fa55f760c770286155
+
+We also patch af_packet PMD to change set flags only when needed
+
+Signed-off-by: Saikrishna Edupuganti <saikrishna.edupuganti@intel.com>
+---
+ drivers/net/af_packet/rte_eth_af_packet.c | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/drivers/net/af_packet/rte_eth_af_packet.c b/drivers/net/af_packet/rte_eth_af_packet.c
+index f5806bf42..29d45eb47 100644
+--- a/drivers/net/af_packet/rte_eth_af_packet.c
++++ b/drivers/net/af_packet/rte_eth_af_packet.c
+@@ -472,6 +472,7 @@ static int
+ eth_dev_change_flags(char *if_name, uint32_t flags, uint32_t mask)
+ {
+ 	struct ifreq ifr;
++	uint32_t cur_flags;
+ 	int ret = 0;
+ 	int s;
+
+@@ -484,8 +485,16 @@ eth_dev_change_flags(char *if_name, uint32_t flags, uint32_t mask)
+ 		ret = -errno;
+ 		goto out;
+ 	}
++
++	cur_flags = ifr.ifr_flags;
+ 	ifr.ifr_flags &= mask;
+ 	ifr.ifr_flags |= flags;
++
++	// Return if there is no change
++	if (cur_flags == ifr.ifr_flags){
++		goto out;
++	}
++
+ 	if (ioctl(s, SIOCSIFFLAGS, &ifr) < 0) {
+ 		ret = -errno;
+ 		goto out;
+--
+2.25.1
+


### PR DESCRIPTION
1. Added pause container using which all routes and interfaces are setup with higher privileges (NET_ADMIN)
2. DPDK 19.11 introduced return codes for pmd promiscuous callbacks, Introduce knob in BESS to explicitly enable promiscuous and ignore dev_start permission error