### PR TITLE
docker login password-stdin

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,7 +19,7 @@ jobs:
         USERNAME: ${{ github.actor }}
         PASSWORD: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        docker login https://docker.pkg.github.com -u $USERNAME -p $PASSWORD
+        echo $PASSWORD | docker login https://docker.pkg.github.com -u $USERNAME --password-stdin
     - name: Build and push Docker image
       run: |
         make docker-build

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -57,7 +57,7 @@ jobs:
           USERNAME: ${{ github.actor }}
           PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          docker login https://docker.pkg.github.com -u $USERNAME -p $PASSWORD
+          echo $PASSWORD | docker login https://docker.pkg.github.com -u $USERNAME --password-stdin
       - name: Push Docker image
         run: |
           make docker-push


### PR DESCRIPTION
removes this warning

```
WARNING! Using --password via the CLI is insecure. Use --password-stdin.
```