### PR TITLE
Flow steering based on SDF and precedence

### DIFF
--- a/conf/parser.py
+++ b/conf/parser.py
@@ -28,9 +28,14 @@ class Parser:
         self.ip_frag_with_eth_mtu = None
         self.measure = False
         self.mode = None
+        self.sim_core = None
         self.sim_start_ue_ip = None
         self.sim_start_enb_ip = None
+        self.sim_start_aupf_ip = None
+        self.sim_n6_app_ip = None
+        self.sim_n9_app_ip = None
         self.sim_start_n3_teid = None
+        self.sim_start_n9_teid = None
         self.sim_pkt_size = None
         self.sim_total_flows = None
         self.workers = 1
@@ -45,7 +50,8 @@ class Parser:
         try:
             self.max_ip_defrag_flows = int(self.conf["max_ip_defrag_flows"])
         except ValueError:
-            print('Invalid value for max_ip_defrag_flows. Not installing IP4Defrag module.')
+            print(
+                'Invalid value for max_ip_defrag_flows. Not installing IP4Defrag module.')
         except KeyError:
             print('max_ip_defrag_flows value not set. Not installing IP4Defrag module.')
 
@@ -53,13 +59,14 @@ class Parser:
         try:
             self.ip_frag_with_eth_mtu = int(self.conf["ip_frag_with_eth_mtu"])
         except ValueError:
-            print('Invalid value for ip_frag_with_eth_mtu. Not installing IP4Frag module.')
+            print(
+                'Invalid value for ip_frag_with_eth_mtu. Not installing IP4Frag module.')
         except KeyError:
             print('ip_frag_with_eth_mtu value not set. Not installing IP4Frag module.')
 
         # Telemtrics
         # See this link for details:
-        ## https://github.com/NetSys/bess/blob/master/bessctl/module_tests/timestamp.py
+        # https://github.com/NetSys/bess/blob/master/bessctl/module_tests/timestamp.py
         try:
             self.measure = bool(self.conf["measure"])
         except ValueError:
@@ -73,7 +80,8 @@ class Parser:
                 self.interfaces[iface] = self.conf[iface]
             except KeyError:
                 self.interfaces[iface] = {'ifname': iface}
-                print('Can\'t read {} interface. Setting it to default ({}).'.format(iface, iface))
+                print('Can\'t read {} interface. Setting it to default ({}).'.format(
+                    iface, iface))
 
         # Detect mode. Default is dpdk
         try:
@@ -83,9 +91,14 @@ class Parser:
 
         # params for simulation
         try:
+            self.sim_core = self.conf["sim"]["core"]
             self.sim_start_ue_ip = self.conf["sim"]["start_ue_ip"]
             self.sim_start_enb_ip = self.conf["sim"]["start_enb_ip"]
+            self.sim_start_aupf_ip = self.conf["sim"]["start_aupf_ip"]
+            self.sim_n6_app_ip = self.conf["sim"]["n6_app_ip"]
+            self.sim_n9_app_ip = self.conf["sim"]["n9_app_ip"]
             self.sim_start_n3_teid = int(self.conf["sim"]["start_n3_teid"], 16)
+            self.sim_start_n9_teid = int(self.conf["sim"]["start_n9_teid"], 16)
             self.sim_pkt_size = self.conf["sim"]["pkt_size"]
             self.sim_total_flows = self.conf["sim"]["total_flows"]
         except ValueError:
@@ -112,7 +125,8 @@ class Parser:
         except KeyError:
             self.access_ifname = "access"
             self.core_ifname = "core"
-            print('Can\'t parse interface name(s)! Setting it to default values ({}, {})'.format("access", "core"))
+            print('Can\'t parse interface name(s)! Setting it to default values ({}, {})'.format(
+                "access", "core"))
 
         # Network Token Function
         try:

--- a/conf/parser.py
+++ b/conf/parser.py
@@ -30,7 +30,7 @@ class Parser:
         self.mode = None
         self.sim_start_ue_ip = None
         self.sim_start_enb_ip = None
-        self.sim_start_teid = None
+        self.sim_start_n3_teid = None
         self.sim_pkt_size = None
         self.sim_total_flows = None
         self.workers = 1
@@ -85,7 +85,7 @@ class Parser:
         try:
             self.sim_start_ue_ip = self.conf["sim"]["start_ue_ip"]
             self.sim_start_enb_ip = self.conf["sim"]["start_enb_ip"]
-            self.sim_start_teid = int(self.conf["sim"]["start_teid"], 16)
+            self.sim_start_n3_teid = int(self.conf["sim"]["start_n3_teid"], 16)
             self.sim_pkt_size = self.conf["sim"]["pkt_size"]
             self.sim_total_flows = self.conf["sim"]["total_flows"]
         except ValueError:

--- a/conf/sim.py
+++ b/conf/sim.py
@@ -11,6 +11,7 @@ from conf.utils import *
 #       SIM Create Packet Functions
 # ====================================================
 
+
 def gen_inet_packet(size, src_mac, dst_mac, src_ip, dst_ip):
     eth = Ether(src=src_mac, dst=dst_mac)
     ip = IP(src=src_ip, dst=dst_ip)
@@ -27,7 +28,7 @@ def get_inet_sequpdate_args(max_session, start_ue_ip):
     return kwargs
 
 
-def gen_ue_packet(size, src_mac, dst_mac, src_ip, dst_ip, inner_src_ip, inner_dst_ip, teid):
+def gen_gtpu_packet(size, src_mac, dst_mac, src_ip, dst_ip, inner_src_ip, inner_dst_ip, teid):
     eth = Ether(src=src_mac, dst=dst_mac)
     ip = IP(src=src_ip, dst=dst_ip)
     udp = UDP(sport=2152, dport=2152)
@@ -114,10 +115,10 @@ def gen_ue_ntf_packet(size, src_mac, dst_mac, src_ip, dst_ip, inner_src_ip, inne
     return bytes(pkt)
 
 
-def get_ue_sequpdate_args(max_session, start_ue_ip, start_teid):
+def get_ue_sequpdate_args(max_session, start_ue_ip, start_n3_teid):
     kwargs = {"fields": [
-        {'offset': 46, 'size': 4, 'min': start_teid,
-         'max': start_teid+max_session-1},
+        {'offset': 46, 'size': 4, 'min': start_n3_teid,
+         'max': start_n3_teid+max_session-1},
         {'offset': 62, 'size': 4, 'min': ip2long(start_ue_ip),
          'max': ip2long(start_ue_ip)+max_session-1}]}
     return kwargs

--- a/conf/sim.py
+++ b/conf/sim.py
@@ -115,10 +115,10 @@ def gen_ue_ntf_packet(size, src_mac, dst_mac, src_ip, dst_ip, inner_src_ip, inne
     return bytes(pkt)
 
 
-def get_ue_sequpdate_args(max_session, start_ue_ip, start_n3_teid):
+def gen_gtpu_sequpdate_args(max_session, start_ue_ip, ue_ip_offset, start_teid):
     kwargs = {"fields": [
-        {'offset': 46, 'size': 4, 'min': start_n3_teid,
-         'max': start_n3_teid+max_session-1},
-        {'offset': 62, 'size': 4, 'min': ip2long(start_ue_ip),
+        {'offset': 46, 'size': 4, 'min': start_teid,
+         'max': start_teid+max_session-1},
+        {'offset': ue_ip_offset, 'size': 4, 'min': ip2long(start_ue_ip),
          'max': ip2long(start_ue_ip)+max_session-1}]}
     return kwargs

--- a/conf/up4-double.bess
+++ b/conf/up4-double.bess
@@ -45,7 +45,7 @@ else:
 
 inet_packets = [sim.gen_inet_packet(128, macstr_u, macstr_d, '172.16.100.1', '16.0.0.1'),
                sim.gen_inet_packet(128, macstr_u, macstr_d, '172.12.55.99', '16.0.0.1')]
-ue_packets = [sim.gen_ue_packet(128, macstr_d, macstr_u, '11.1.1.128', '11.1.1.1', '16.0.0.1', '172.16.100.1')]
+ue_packets = [sim.gen_gtpu_packet(128, macstr_d, macstr_u, '11.1.1.128', '11.1.1.1', '16.0.0.1', '172.16.100.1')]
 packet_generator = {'s1u': ue_packets, 'sgi': inet_packets}
 
 

--- a/conf/up4.bess
+++ b/conf/up4.bess
@@ -38,29 +38,47 @@ core_ip = ips_by_interface(parser.core_ifname)
 if parser.mode == 'sim':
     macstr_d = '00:00:00:00:00:02'
     macstr_u = '00:00:00:00:00:01'
-    inet_packets = [sim.gen_inet_packet(parser.sim_pkt_size, macstr_u, macstr_d,
-                                        '172.16.100.1', parser.sim_start_ue_ip),
-                    sim.gen_inet_packet(parser.sim_pkt_size, macstr_u, macstr_d,
-                                        '172.12.55.99', parser.sim_start_ue_ip)]
-    ue_packets = [sim.gen_gtpu_packet(parser.sim_pkt_size, macstr_d, macstr_u,
+    n36_pkts = [sim.gen_gtpu_packet(parser.sim_pkt_size, macstr_d, macstr_u,
                                     parser.sim_start_enb_ip, access_ip[0],
-                                    parser.sim_start_ue_ip, '172.16.100.1',
+                                    parser.sim_start_ue_ip, parser.sim_n6_app_ip,
                                     parser.sim_start_n3_teid)]
+
+    n39_pkts = [sim.gen_gtpu_packet(parser.sim_pkt_size, macstr_d, macstr_u,
+                                    parser.sim_start_enb_ip, access_ip[0],
+                                    parser.sim_start_ue_ip, parser.sim_n9_app_ip,
+                                    parser.sim_start_n3_teid)]
+
+    n63_pkts = [sim.gen_inet_packet(parser.sim_pkt_size, macstr_u, macstr_d,
+                                    parser.sim_n6_app_ip, parser.sim_start_ue_ip)]
+
+    n93_pkts = [sim.gen_gtpu_packet(parser.sim_pkt_size, macstr_d, macstr_u,
+                                    parser.sim_start_aupf_ip, core_ip[0],
+                                    parser.sim_n9_app_ip, parser.sim_start_ue_ip,
+                                    parser.sim_start_n9_teid)]
     if parser.enable_ntf:
         # Every 30th packet will be a STUN packet.  With 5000 flows, this
         # results in about 1000 flows with network tokens, and every 3rd packet
         # is a STUN packet with a token.  This is not a good representation of
         # a real world test, but it is enough to verify that NTF can match
         # tokens and pass traffic through with mode="sim".
-        ue_packets = ue_packets * 29
-        ue_packets.append(
+        n36_pkts = n36_pkts * 29
+        n36_pkts.append(
           sim.gen_ue_ntf_packet(parser.sim_pkt_size, macstr_d, macstr_u,
                                 parser.sim_start_enb_ip, access_ip[0],
-                                parser.sim_start_ue_ip, '172.16.100.1',
+                                parser.sim_start_ue_ip, parser.sim_n6_app_ip,
                                 parser.sim_start_n3_teid))
-    packet_generator = {'access': ue_packets, 'core': inet_packets}
-    seq_kwargs = {'access': sim.get_ue_sequpdate_args(parser.sim_total_flows, parser.sim_start_ue_ip, parser.sim_start_n3_teid),
-                  'core': sim.get_inet_sequpdate_args(parser.sim_total_flows, parser.sim_start_ue_ip)}
+
+    n3_seq = sim.gen_gtpu_sequpdate_args(parser.sim_total_flows, parser.sim_start_ue_ip, 62, parser.sim_start_n3_teid)
+    n6_seq = sim.get_inet_sequpdate_args(parser.sim_total_flows, parser.sim_start_ue_ip)
+    n9_seq = sim.gen_gtpu_sequpdate_args(parser.sim_total_flows, parser.sim_start_ue_ip, 66, parser.sim_start_n9_teid)
+
+    if parser.sim_core == "n6":
+        packet_generator = {'access': n36_pkts, 'core': n63_pkts}
+        seq_kwargs = {'access': n3_seq, 'core': n6_seq}
+    else:
+        packet_generator = {'access': n39_pkts, 'core': n93_pkts}
+        seq_kwargs = {'access': n3_seq, 'core': n9_seq}
+
 else:
     macstr_d = mac_by_interface(parser.core_ifname)
     macstr_u = mac_by_interface(parser.access_ifname)

--- a/conf/up4.bess
+++ b/conf/up4.bess
@@ -16,8 +16,6 @@ port.setup_globals()
 
 Access = 1
 Core = 2
-Uplink = 0
-Downlink = 1
 noGTPUDecap = 0
 GTPUDecap = 1
 noGTPUEncap = 0
@@ -154,10 +152,10 @@ linkMerge::Merge() \
     -> pdrLookup::WildcardMatch(fields=[{'attr_name':'src_iface', 'num_bytes':1}, \
                                         {'attr_name':'tunnel_ipv4_dst', 'num_bytes':4}, \
                                         {'attr_name':'teid', 'num_bytes':4}, \
-                                        {'attr_name':'dst_ip', 'num_bytes':4}, \
                                         {'attr_name':'src_ip', 'num_bytes':4}, \
-                                        {'attr_name':'dst_port', 'num_bytes':2}, \
+                                        {'attr_name':'dst_ip', 'num_bytes':4}, \
                                         {'attr_name':'src_port', 'num_bytes':2}, \
+                                        {'attr_name':'dst_port', 'num_bytes':2}, \
                                         {'attr_name':'ip_proto', 'num_bytes':1}], \
                                 values=[{'attr_name':'pdr_id', 'num_bytes':4}, \
                                         {'attr_name':'fseid', 'num_bytes':4}, \

--- a/conf/up4.bess
+++ b/conf/up4.bess
@@ -42,10 +42,10 @@ if parser.mode == 'sim':
                                         '172.16.100.1', parser.sim_start_ue_ip),
                     sim.gen_inet_packet(parser.sim_pkt_size, macstr_u, macstr_d,
                                         '172.12.55.99', parser.sim_start_ue_ip)]
-    ue_packets = [sim.gen_ue_packet(parser.sim_pkt_size, macstr_d, macstr_u,
+    ue_packets = [sim.gen_gtpu_packet(parser.sim_pkt_size, macstr_d, macstr_u,
                                     parser.sim_start_enb_ip, access_ip[0],
                                     parser.sim_start_ue_ip, '172.16.100.1',
-                                    parser.sim_start_teid)]
+                                    parser.sim_start_n3_teid)]
     if parser.enable_ntf:
         # Every 30th packet will be a STUN packet.  With 5000 flows, this
         # results in about 1000 flows with network tokens, and every 3rd packet
@@ -57,9 +57,9 @@ if parser.mode == 'sim':
           sim.gen_ue_ntf_packet(parser.sim_pkt_size, macstr_d, macstr_u,
                                 parser.sim_start_enb_ip, access_ip[0],
                                 parser.sim_start_ue_ip, '172.16.100.1',
-                                parser.sim_start_teid))
+                                parser.sim_start_n3_teid))
     packet_generator = {'access': ue_packets, 'core': inet_packets}
-    seq_kwargs = {'access': sim.get_ue_sequpdate_args(parser.sim_total_flows, parser.sim_start_ue_ip, parser.sim_start_teid),
+    seq_kwargs = {'access': sim.get_ue_sequpdate_args(parser.sim_total_flows, parser.sim_start_ue_ip, parser.sim_start_n3_teid),
                   'core': sim.get_inet_sequpdate_args(parser.sim_total_flows, parser.sim_start_ue_ip)}
 else:
     macstr_d = mac_by_interface(parser.core_ifname)

--- a/conf/upf.json
+++ b/conf/upf.json
@@ -9,6 +9,7 @@
 
     "": "Use the sim block to enable simulation using either Source module or via il_trafficgen",
     "sim": {
+        "": "At this point we can simulate either N3/N6 or N3/N9 traffic, so choose n6 or n9 below",
         "core": "n6",
         "start_ue_ip": "16.0.0.1",
         "start_enb_ip": "11.1.1.129",

--- a/conf/upf.json
+++ b/conf/upf.json
@@ -9,6 +9,7 @@
 
     "": "Use the sim block to enable simulation using either Source module or via il_trafficgen",
     "sim": {
+        "core": "n6",
         "start_ue_ip": "16.0.0.1",
         "start_enb_ip": "11.1.1.129",
         "start_aupf_ip": "13.1.1.199",

--- a/conf/upf.json
+++ b/conf/upf.json
@@ -11,7 +11,11 @@
     "sim": {
         "start_ue_ip": "16.0.0.1",
         "start_enb_ip": "11.1.1.129",
-        "start_teid": "0xf0000000",
+        "start_aupf_ip": "13.1.1.199",
+        "n6_app_ip": "6.6.6.6",
+        "n9_app_ip": "9.9.9.9",
+        "start_n3_teid": "0x30000000",
+        "start_n9_teid": "0x90000000",
         "pkt_size": 128,
         "total_flows": 5000
     },

--- a/core/modules/gtpu_parser.cc
+++ b/core/modules/gtpu_parser.cc
@@ -72,7 +72,7 @@ void GtpuParser::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
       case Ipv4::kUdp:
         udph = (Udp *)((char *)iph + (iph->header_length << 2));
         if (udph->dst_port == (be16_t)(UDP_PORT_GTPU)) {
-	  Ipv4 *old_iph = iph;
+          Ipv4 *old_iph = iph;
           gtph = (Gtpv1 *)(udph + 1);
           be32_t teid = (be32_t)gtph->teid.value();
           /* reuse iph, tcph, and udph for innser headers too */

--- a/core/modules/gtpu_parser.cc
+++ b/core/modules/gtpu_parser.cc
@@ -72,6 +72,7 @@ void GtpuParser::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
       case Ipv4::kUdp:
         udph = (Udp *)((char *)iph + (iph->header_length << 2));
         if (udph->dst_port == (be16_t)(UDP_PORT_GTPU)) {
+	  Ipv4 *old_iph = iph;
           gtph = (Gtpv1 *)(udph + 1);
           be32_t teid = (be32_t)gtph->teid.value();
           /* reuse iph, tcph, and udph for innser headers too */
@@ -80,16 +81,16 @@ void GtpuParser::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
             tcph = (Tcp *)((char *)iph + (iph->header_length << 2));
             set_gtp_parsing_attrs(&iph->src, &iph->dst, &tcph->src_port,
                                   &tcph->dst_port, (be32_t *)&teid,
-                                  (be32_t *)&_const_val, &iph->protocol, p);
+                                  &old_iph->dst, &iph->protocol, p);
           } else if (iph->protocol == Ipv4::kUdp) {
             udph = (Udp *)((char *)iph + (iph->header_length << 2));
             set_gtp_parsing_attrs(&iph->src, &iph->dst, &udph->src_port,
                                   &udph->dst_port, (be32_t *)&teid,
-                                  (be32_t *)&_const_val, &iph->protocol, p);
+                                  &old_iph->dst, &iph->protocol, p);
           } else {
             set_gtp_parsing_attrs(&iph->src, &iph->dst, (be16_t *)&_const_val,
                                   (be16_t *)&_const_val, (be32_t *)&teid,
-                                  (be32_t *)&_const_val, &iph->protocol, p);
+                                  &old_iph->dst, &iph->protocol, p);
           }
         } else {
           set_gtp_parsing_attrs(&iph->src, &iph->dst, &udph->src_port,

--- a/cpiface/bess_control.h
+++ b/cpiface/bess_control.h
@@ -125,21 +125,21 @@ class BessClient {
     bess::pb::FieldData *_teid = wmcaa->add_values();
     _teid->set_value_int(pa->enb_teid);
 
-    /* set dst ip */
-    bess::pb::FieldData *dst_ip = wmcaa->add_values();
-    dst_ip->set_value_int(pa->saddr);
-
     /* set src ip */
     bess::pb::FieldData *src_ip = wmcaa->add_values();
     src_ip->set_value_int(pa->daddr);
 
-    /* set dst l4 port */
-    bess::pb::FieldData *l4_dstport = wmcaa->add_values();
-    l4_dstport->set_value_int(pa->sport);
+    /* set dst ip */
+    bess::pb::FieldData *dst_ip = wmcaa->add_values();
+    dst_ip->set_value_int(pa->saddr);
 
     /* set src l4 port */
     bess::pb::FieldData *l4_srcport = wmcaa->add_values();
     l4_srcport->set_value_int(pa->dport);
+
+    /* set dst l4 port */
+    bess::pb::FieldData *l4_dstport = wmcaa->add_values();
+    l4_dstport->set_value_int(pa->sport);
 
     /* set proto id */
     bess::pb::FieldData *_protoid = wmcaa->add_values();
@@ -159,21 +159,21 @@ class BessClient {
     _teid = wmcaa->add_masks();
     _teid->set_value_int(pa->enb_teid_mask);
 
-    /* set dst ip */
-    dst_ip = wmcaa->add_masks();
-    dst_ip->set_value_int(pa->saddr_mask);
-
     /* set src ip */
     src_ip = wmcaa->add_masks();
     src_ip->set_value_int(pa->daddr_mask);
 
-    /* set dst l4 port */
-    l4_dstport = wmcaa->add_masks();
-    l4_dstport->set_value_int(pa->sport_mask);
+    /* set dst ip */
+    dst_ip = wmcaa->add_masks();
+    dst_ip->set_value_int(pa->saddr_mask);
 
     /* set src l4 port */
     l4_srcport = wmcaa->add_masks();
     l4_srcport->set_value_int(pa->dport_mask);
+
+    /* set dst l4 port */
+    l4_dstport = wmcaa->add_masks();
+    l4_dstport->set_value_int(pa->sport_mask);
 
     /* set proto id */
     _protoid = wmcaa->add_masks();

--- a/pfcpiface/main.go
+++ b/pfcpiface/main.go
@@ -167,7 +167,7 @@ func main() {
 
 	log.Println("N4 IP: ", n4SrcIP.String())
 
-	go pfcpifaceMainLoop(upf, accessIP.String(), n4SrcIP.String())
+	go pfcpifaceMainLoop(upf, accessIP.String(), coreIP.String(), n4SrcIP.String())
 
 	setupProm(upf)
 	log.Fatal(http.ListenAndServe(*httpAddr, nil))

--- a/pfcpiface/main.go
+++ b/pfcpiface/main.go
@@ -40,9 +40,13 @@ type Conf struct {
 
 // SimModeInfo : Sim mode attributes
 type SimModeInfo struct {
-	StartUeIP    string `json:"start_ue_ip"`
-	StartEnodeIP string `json:"start_enb_ip"`
-	StartTeid    string `json:"start_teid"`
+	StartUEIP   net.IP `json:"start_ue_ip"`
+	StartENBIP  net.IP `json:"start_enb_ip"`
+	StartAUPFIP net.IP `json:"start_aupf_ip"`
+	N6AppIP     net.IP `json:"n6_app_ip"`
+	N9AppIP     net.IP `json:"n9_app_ip"`
+	StartN3TEID string `json:"start_n3_teid"`
+	StartN9TEID string `json:"start_n9_teid"`
 }
 
 // CPIfaceInfo : CPIface interface settings

--- a/pfcpiface/parser.go
+++ b/pfcpiface/parser.go
@@ -80,7 +80,7 @@ func parseCreatePDRPDI(pdi []*ie.IE) (srcIface uint8, teid uint32, ueIP4 net.IP,
 			} else {
 				flowDesc := sdfFields.FlowDescription
 				if flowDesc != "" {
-					inetIP4Address := parseFlowDesc(flowDesc)
+					inetIP4Address = parseFlowDesc(flowDesc)
 					log.Println("Flow Description is:", inetIP4Address)
 				}
 			}
@@ -149,7 +149,7 @@ func parseCreatePDR(ie1 *ie.IE, fseid *ie.FSEIDFields) *pdr {
 		dstIP4 = net.IP("0.0.0.0")
 	}
 
-	if len(dstIP4) == 0 {
+	if dstIP4.String() == "0.0.0.0" {
 		dstIP = 0
 		dstIPMask = 0
 	} else {

--- a/pfcpiface/parser.go
+++ b/pfcpiface/parser.go
@@ -115,7 +115,6 @@ func parseCreatePDRPDI(pdi []*ie.IE) *pdr {
 				pdrI.dstIPMask = ueIPMask
 			}
 		case ie.SDFFilter:
-			inetIP4Address := "0.0.0.0/0"
 			// Do nothing for the time being
 			sdfFields, err := ie2.SDFFilter()
 			if err != nil {
@@ -129,7 +128,7 @@ func parseCreatePDRPDI(pdi []*ie.IE) *pdr {
 				// TODO: Implement referencing SDF ID
 				continue
 			}
-			inetIP4Address = parseFlowDesc(flowDesc)
+			inetIP4Address := parseFlowDesc(flowDesc)
 			log.Println("Flow Description is:", inetIP4Address)
 
 			dstIP4, dstIP4Net, err := net.ParseCIDR(inetIP4Address)

--- a/pfcpiface/pfcpiface.go
+++ b/pfcpiface/pfcpiface.go
@@ -265,7 +265,7 @@ func handleSessionModificationRequest(upf *upf, msg message.Message, addr net.Ad
 		for _, ie1 := range ies1 {
 			switch ie1.Type {
 			case ie.UpdateFAR:
-				if f := parseUpdateFAR(ie1, fseid, upf.accessIP, farForwardD); f != nil {
+				if f := parseUpdateFAR(ie1, fseid, upf.accessIP); f != nil {
 					fars = append(fars, *f)
 				}
 			default:

--- a/pfcpiface/pfcpiface.go
+++ b/pfcpiface/pfcpiface.go
@@ -152,8 +152,7 @@ func handleAssociationSetupRequest(msg message.Message, addr net.Addr, sourceIP 
 		// 0x41 = Spare (0) | Assoc Src Inst (1) | Assoc Net Inst (0) | Tied Range (000) | IPV6 (0) | IPV4 (1)
 		//      = 01000001
 		ie.NewUserPlaneIPResourceInformation(0x41, 0, accessIP, "", "", ie.SrcInterfaceAccess),
-		ie.NewUserPlaneIPResourceInformation(0x41, 0, coreIP, "", "", ie.SrcInterfaceCore),
-		ie.NewSequenceNumber(asreq.SequenceNumber), /* seq # */
+		//ie.NewUserPlaneIPResourceInformation(0x41, 0, coreIP, "", "", ie.SrcInterfaceCore),
 	).Marshal() /* userplane ip resource info */
 	if err != nil {
 		log.Fatalln("Unable to create association setup response", err)

--- a/pfcpiface/upf.go
+++ b/pfcpiface/upf.go
@@ -82,6 +82,32 @@ type far struct {
 	UDPGTPUPort uint16
 }
 
+func printPDR(pdr pdr) {
+	log.Println("------------------ PDR ---------------------")
+	log.Println("Src Iface:", pdr.srcIface)
+	log.Println("tunnelIP4Dst:", int2ip(pdr.tunnelIP4Dst))
+	log.Println("eNBTeid:", pdr.eNBTeid)
+	log.Println("srcIP:", int2ip(pdr.srcIP))
+	log.Println("dstIP:", int2ip(pdr.dstIP))
+	log.Println("srcPort:", pdr.srcPort)
+	log.Println("dstPort:", pdr.dstPort)
+	log.Println("proto:", pdr.proto)
+	log.Println("Src Iface Mask:", pdr.srcIfaceMask)
+	log.Println("tunnelIP4Dst Mask:", int2ip(pdr.tunnelIP4DstMask))
+	log.Println("eNBTeid Mask:", pdr.eNBTeidMask)
+	log.Println("srcIP Mask:", int2ip(pdr.srcIPMask))
+	log.Println("dstIP Mask:", int2ip(pdr.dstIPMask))
+	log.Println("srcPort Mask:", pdr.srcPortMask)
+	log.Println("dstPort Mask:", pdr.dstPortMask)
+	log.Println("proto Mask:", pdr.protoMask)
+	log.Println("pdrID:", pdr.pdrID)
+	log.Println("fseID", pdr.fseID)
+	log.Println("ctrID:", pdr.ctrID)
+	log.Println("farID:", pdr.farID)
+	log.Println("needDecap:", pdr.needDecap)
+	log.Println("--------------------------------------------")
+}
+
 var intEnc = func(u uint64) *pb.FieldData {
 	return &pb.FieldData{Encoding: &pb.FieldData_ValueInt{ValueInt: u}}
 }

--- a/pfcpiface/upf.go
+++ b/pfcpiface/upf.go
@@ -29,15 +29,16 @@ type upf struct {
 
 // Don't change these values
 const (
-	udpGTPUPort = 2152
+	tunnelPort = 2152
 
 	// src-iface consts
 	core   = 0x2
 	access = 0x1
 
 	// far-id specific directions
-	uplink   = 0x0
-	downlink = 0x1
+	n3 = 0x0
+	n6 = 0x1
+	n9 = 0x2
 
 	// far-action specific values
 	farForwardU = 0x0
@@ -47,7 +48,7 @@ const (
 type pdr struct {
 	srcIface     uint8
 	tunnelIP4Dst uint32
-	eNBTeid      uint32
+	tunnelTEID   uint32
 	srcIP        uint32
 	dstIP        uint32
 	srcPort      uint16
@@ -56,37 +57,38 @@ type pdr struct {
 
 	srcIfaceMask     uint8
 	tunnelIP4DstMask uint32
-	eNBTeidMask      uint32
+	tunnelTEIDMask   uint32
 	srcIPMask        uint32
 	dstIPMask        uint32
 	srcPortMask      uint16
 	dstPortMask      uint16
 	protoMask        uint8
 
-	pdrID     uint32
-	fseID     uint32
-	ctrID     uint32
-	farID     uint8
-	needDecap uint8
+	precedence uint32
+	pdrID      uint32
+	fseID      uint32
+	ctrID      uint32
+	farID      uint8
+	needDecap  uint8
 }
 
 type far struct {
 	farID uint8
 	fseID uint32
 
-	action      uint8
-	tunnelType  uint8
-	accessIP    uint32
-	eNBIP       uint32
-	eNBTeid     uint32
-	UDPGTPUPort uint16
+	action       uint8
+	tunnelType   uint8
+	tunnelIP4Src uint32
+	tunnelIP4Dst uint32
+	tunnelTEID   uint32
+	tunnelPort   uint16
 }
 
 func printPDR(pdr pdr) {
 	log.Println("------------------ PDR ---------------------")
 	log.Println("Src Iface:", pdr.srcIface)
 	log.Println("tunnelIP4Dst:", int2ip(pdr.tunnelIP4Dst))
-	log.Println("eNBTeid:", pdr.eNBTeid)
+	log.Println("tunnelTEID:", pdr.tunnelTEID)
 	log.Println("srcIP:", int2ip(pdr.srcIP))
 	log.Println("dstIP:", int2ip(pdr.dstIP))
 	log.Println("srcPort:", pdr.srcPort)
@@ -94,7 +96,7 @@ func printPDR(pdr pdr) {
 	log.Println("proto:", pdr.proto)
 	log.Println("Src Iface Mask:", pdr.srcIfaceMask)
 	log.Println("tunnelIP4Dst Mask:", int2ip(pdr.tunnelIP4DstMask))
-	log.Println("eNBTeid Mask:", pdr.eNBTeidMask)
+	log.Println("tunnelTEIDMask Mask:", pdr.tunnelTEIDMask)
 	log.Println("srcIP Mask:", int2ip(pdr.srcIPMask))
 	log.Println("dstIP Mask:", int2ip(pdr.dstIPMask))
 	log.Println("srcPort Mask:", pdr.srcPortMask)
@@ -114,10 +116,10 @@ func printFAR(far far) {
 	log.Println("fseID:", far.fseID)
 	log.Println("action:", far.action)
 	log.Println("tunnelType:", far.tunnelType)
-	log.Println("accessIP:", far.accessIP)
-	log.Println("eNBIP:", far.eNBIP)
-	log.Println("eNBTeid:", far.eNBTeid)
-	log.Println("UDPGTPUPort:", far.UDPGTPUPort)
+	log.Println("tunnelIP4Src:", far.tunnelIP4Src)
+	log.Println("tunnelIP4Dst:", far.tunnelIP4Dst)
+	log.Println("tunnelTEID:", far.tunnelTEID)
+	log.Println("tunnelPort:", far.tunnelPort)
 	log.Println("--------------------------------------------")
 }
 
@@ -135,9 +137,14 @@ func (u *upf) sim(method string) {
 	}
 
 	//const ueip, teid, enbip = 0x10000001, 0xf0000000, 0x0b010181
-	ueip, teid, enbip := net.ParseIP(u.simInfo.StartUeIP), hex2int(u.simInfo.StartTeid), net.ParseIP(u.simInfo.StartEnodeIP)
+	ueip := u.simInfo.StartUEIP
+	enbip := u.simInfo.StartENBIP
+	aupfip := u.simInfo.StartAUPFIP
+	n9appip := u.simInfo.N9AppIP
+	n3TEID := hex2int(u.simInfo.StartN3TEID)
+	n9TEID := hex2int(u.simInfo.StartN9TEID)
+
 	const ng4tMaxUeRan, ng4tMaxEnbRan = 500000, 80
-	accessIP := ip2int(u.accessIP)
 
 	for i := uint32(0); i < u.maxSessions; i++ {
 		// NG4T-based formula to calculate enodeB IP address against a given UE IP address
@@ -149,53 +156,113 @@ func (u *upf) sim(method string) {
 		enbIdx := ran*ng4tMaxEnbRan + enbOfRan
 
 		// create/delete downlink pdr
-		pdrDown := pdr{
-			srcIface:     core,
-			dstIP:        ip2int(ueip) + i,
+		pdrN6Down := pdr{
+			srcIface: core,
+			dstIP:    ip2int(ueip) + i,
+
 			srcIfaceMask: 0xFF,
 			dstIPMask:    0xFFFFFFFF,
-			fseID:        teid + i,
-			ctrID:        i,
-			farID:        downlink,
-			needDecap:    0,
+
+			precedence: 10,
+
+			fseID:     n3TEID + i,
+			ctrID:     i,
+			farID:     n3,
+			needDecap: 0,
+		}
+
+		pdrN9Down := pdr{
+			srcIface:     core,
+			tunnelTEID:   n9TEID + i,
+			tunnelIP4Dst: ip2int(u.coreIP),
+
+			srcIfaceMask:     0xFF,
+			tunnelTEIDMask:   0xFFFFFFFF,
+			tunnelIP4DstMask: 0xFFFFFFFF,
+
+			precedence: 20,
+
+			fseID:     n9TEID + i,
+			ctrID:     i,
+			farID:     n3,
+			needDecap: 1,
 		}
 
 		// create/delete uplink pdr
-		pdrUp := pdr{
+		pdrN6Up := pdr{
 			srcIface:     access,
-			eNBTeid:      teid + i,
+			tunnelIP4Dst: ip2int(u.accessIP),
+			tunnelTEID:   n3TEID + i,
 			srcIP:        ip2int(ueip) + i,
-			srcIfaceMask: 0xFF,
-			eNBTeidMask:  0xFFFFFFFF,
-			srcIPMask:    0xFFFFFFFF,
-			fseID:        teid + i,
-			ctrID:        i,
-			farID:        uplink,
-			needDecap:    1,
+
+			srcIfaceMask:     0xFF,
+			tunnelIP4DstMask: 0xFFFFFFFF,
+			tunnelTEIDMask:   0xFFFFFFFF,
+			srcIPMask:        0xFFFFFFFF,
+
+			precedence: 10,
+
+			fseID:     n3TEID + i,
+			ctrID:     i,
+			farID:     n6,
+			needDecap: 1,
 		}
 
-		pdrs := []pdr{pdrUp, pdrDown}
+		pdrN9Up := pdr{
+			srcIface:     access,
+			tunnelIP4Dst: ip2int(u.accessIP),
+			tunnelTEID:   n3TEID + i,
+			dstIP:        ip2int(n9appip),
+
+			srcIfaceMask:     0xFF,
+			tunnelIP4DstMask: 0xFFFFFFFF,
+			tunnelTEIDMask:   0xFFFFFFFF,
+			dstIPMask:        0xFFFFFFFF,
+
+			precedence: 20,
+
+			fseID:     n3TEID + i,
+			ctrID:     i,
+			farID:     n9,
+			needDecap: 1,
+		}
+
+		pdrs := []pdr{pdrN6Down, pdrN9Down, pdrN6Up, pdrN9Up}
 
 		// create/delete downlink far
 		farDown := far{
-			farID:       downlink,
-			fseID:       teid + i,
-			action:      farForwardD,
-			tunnelType:  0x1,
-			accessIP:    accessIP,
-			eNBIP:       ip2int(enbip) + enbIdx,
-			eNBTeid:     teid + i,
-			UDPGTPUPort: udpGTPUPort,
+			farID: n3,
+			fseID: n3TEID + i,
+
+			action:       farForwardD,
+			tunnelType:   0x1,
+			tunnelIP4Src: ip2int(u.accessIP),
+			tunnelIP4Dst: ip2int(enbip) + enbIdx,
+			tunnelTEID:   n3TEID + i,
+			tunnelPort:   tunnelPort,
 		}
 
 		// create/delete uplink far
-		farUp := far{
-			farID:  uplink,
-			fseID:  teid + i,
+		farN6Up := far{
+			farID: n6,
+			fseID: n3TEID + i,
+
 			action: farForwardU,
 		}
 
-		fars := []far{farDown, farUp}
+		farN9Up := far{
+			farID: n9,
+			fseID: n3TEID + i,
+
+			action:       farForwardU,
+			tunnelType:   0x1,
+			tunnelIP4Src: ip2int(u.coreIP),
+			tunnelIP4Dst: ip2int(aupfip),
+			tunnelTEID:   n9TEID + i,
+			tunnelPort:   tunnelPort,
+		}
+
+		fars := []far{farDown, farN6Up, farN9Up}
 
 		switch timeout := 100 * time.Millisecond; method {
 		case "create":
@@ -359,25 +426,13 @@ func (u *upf) addPDR(ctx context.Context, done chan<- bool, p pdr) {
 		var any *anypb.Any
 		var err error
 
-		prio := int64(1)
-
-		if p.srcIface == core && p.tunnelIP4DstMask != 0 {
-			log.Println("**********Setting priority to 10****************")
-			prio = 10
-		}
-		/*
-			if p.srcIface == access && p.dstIPMask != 0 {
-				log.Println("**********Setting priority to 10****************")
-				prio = 10
-			}
-		*/
 		f := &pb.WildcardMatchCommandAddArg{
 			Gate:     uint64(p.needDecap),
-			Priority: prio,
+			Priority: int64(p.precedence),
 			Values: []*pb.FieldData{
 				intEnc(uint64(p.srcIface)),     /* src_iface */
 				intEnc(uint64(p.tunnelIP4Dst)), /* tunnel_ipv4_dst */
-				intEnc(uint64(p.eNBTeid)),      /* enb_teid */
+				intEnc(uint64(p.tunnelTEID)),   /* enb_teid */
 				intEnc(uint64(p.srcIP)),        /* ueaddr ip*/
 				intEnc(uint64(p.dstIP)),        /* inet ip */
 				intEnc(uint64(p.srcPort)),      /* ue port */
@@ -387,7 +442,7 @@ func (u *upf) addPDR(ctx context.Context, done chan<- bool, p pdr) {
 			Masks: []*pb.FieldData{
 				intEnc(uint64(p.srcIfaceMask)),     /* src_iface-mask */
 				intEnc(uint64(p.tunnelIP4DstMask)), /* tunnel_ipv4_dst-mask */
-				intEnc(uint64(p.eNBTeidMask)),      /* enb_teid-mask */
+				intEnc(uint64(p.tunnelTEIDMask)),   /* enb_teid-mask */
 				intEnc(uint64(p.srcIPMask)),        /* ueaddr ip-mask */
 				intEnc(uint64(p.dstIPMask)),        /* inet ip-mask */
 				intEnc(uint64(p.srcPortMask)),      /* ue port-mask */
@@ -421,7 +476,7 @@ func (u *upf) delPDR(ctx context.Context, done chan<- bool, p pdr) {
 			Values: []*pb.FieldData{
 				intEnc(uint64(p.srcIface)),     /* src_iface */
 				intEnc(uint64(p.tunnelIP4Dst)), /* tunnel_ipv4_dst */
-				intEnc(uint64(p.eNBTeid)),      /* enb_teid */
+				intEnc(uint64(p.tunnelTEID)),   /* enb_teid */
 				intEnc(uint64(p.srcIP)),        /* ueaddr ip*/
 				intEnc(uint64(p.dstIP)),        /* inet ip */
 				intEnc(uint64(p.srcPort)),      /* ue port */
@@ -431,7 +486,7 @@ func (u *upf) delPDR(ctx context.Context, done chan<- bool, p pdr) {
 			Masks: []*pb.FieldData{
 				intEnc(uint64(p.srcIfaceMask)),     /* src_iface-mask */
 				intEnc(uint64(p.tunnelIP4DstMask)), /* tunnel_ipv4_dst-mask */
-				intEnc(uint64(p.eNBTeidMask)),      /* enb_teid-mask */
+				intEnc(uint64(p.tunnelTEIDMask)),   /* enb_teid-mask */
 				intEnc(uint64(p.srcIPMask)),        /* ueaddr ip-mask */
 				intEnc(uint64(p.dstIPMask)),        /* inet ip-mask */
 				intEnc(uint64(p.srcPortMask)),      /* ue port-mask */
@@ -480,12 +535,12 @@ func (u *upf) addFAR(ctx context.Context, done chan<- bool, far far) {
 				intEnc(uint64(far.fseID)), /* fseid */
 			},
 			Values: []*pb.FieldData{
-				intEnc(uint64(far.action)),      /* action */
-				intEnc(uint64(far.tunnelType)),  /* tunnel_out_type */
-				intEnc(uint64(far.accessIP)),    /* access-ip */
-				intEnc(uint64(far.eNBIP)),       /* enb ip */
-				intEnc(uint64(far.eNBTeid)),     /* enb teid */
-				intEnc(uint64(far.UDPGTPUPort)), /* udp gtpu port */
+				intEnc(uint64(far.action)),       /* action */
+				intEnc(uint64(far.tunnelType)),   /* tunnel_out_type */
+				intEnc(uint64(far.tunnelIP4Src)), /* access-ip */
+				intEnc(uint64(far.tunnelIP4Dst)), /* enb ip */
+				intEnc(uint64(far.tunnelTEID)),   /* enb teid */
+				intEnc(uint64(far.tunnelPort)),   /* udp gtpu port */
 			},
 		}
 		any, err = ptypes.MarshalAny(f)

--- a/pfcpiface/upf.go
+++ b/pfcpiface/upf.go
@@ -151,9 +151,9 @@ func (u *upf) sim(method string) {
 		// create/delete downlink pdr
 		pdrDown := pdr{
 			srcIface:     core,
-			srcIP:        ip2int(ueip) + i,
+			dstIP:        ip2int(ueip) + i,
 			srcIfaceMask: 0xFF,
-			srcIPMask:    0xFFFFFFFF,
+			dstIPMask:    0xFFFFFFFF,
 			fseID:        teid + i,
 			ctrID:        i,
 			farID:        downlink,
@@ -164,10 +164,10 @@ func (u *upf) sim(method string) {
 		pdrUp := pdr{
 			srcIface:     access,
 			eNBTeid:      teid + i,
-			dstIP:        ip2int(ueip) + i,
+			srcIP:        ip2int(ueip) + i,
 			srcIfaceMask: 0xFF,
 			eNBTeidMask:  0xFFFFFFFF,
-			dstIPMask:    0xFFFFFFFF,
+			srcIPMask:    0xFFFFFFFF,
 			fseID:        teid + i,
 			ctrID:        i,
 			farID:        uplink,

--- a/pfcpiface/upf.go
+++ b/pfcpiface/upf.go
@@ -108,6 +108,19 @@ func printPDR(pdr pdr) {
 	log.Println("--------------------------------------------")
 }
 
+func printFAR(far far) {
+	log.Println("------------------ FAR ---------------------")
+	log.Println("FAR ID:", far.farID)
+	log.Println("fseID:", far.fseID)
+	log.Println("action:", far.action)
+	log.Println("tunnelType:", far.tunnelType)
+	log.Println("accessIP:", far.accessIP)
+	log.Println("eNBIP:", far.eNBIP)
+	log.Println("eNBTeid:", far.eNBTeid)
+	log.Println("UDPGTPUPort:", far.UDPGTPUPort)
+	log.Println("--------------------------------------------")
+}
+
 var intEnc = func(u uint64) *pb.FieldData {
 	return &pb.FieldData{Encoding: &pb.FieldData_ValueInt{ValueInt: u}}
 }
@@ -347,9 +360,21 @@ func (u *upf) addPDR(ctx context.Context, done chan<- bool, p pdr) {
 		var any *anypb.Any
 		var err error
 
+		prio := int64(1)
+
+		if p.srcIface == core && p.tunnelIP4DstMask != 0 {
+			log.Println("**********Setting priority to 10****************")
+			prio = 10
+		}
+		/*
+			if p.srcIface == access && p.dstIPMask != 0 {
+				log.Println("**********Setting priority to 10****************")
+				prio = 10
+			}
+		*/
 		f := &pb.WildcardMatchCommandAddArg{
 			Gate:     uint64(p.needDecap),
-			Priority: 1,
+			Priority: prio,
 			Values: []*pb.FieldData{
 				intEnc(uint64(p.srcIface)),     /* src_iface */
 				intEnc(uint64(p.tunnelIP4Dst)), /* tunnel_ipv4_dst */

--- a/pfcpiface/upf.go
+++ b/pfcpiface/upf.go
@@ -182,7 +182,7 @@ func (u *upf) sim(method string) {
 
 			precedence: 20,
 
-			fseID:     n9TEID + i,
+			fseID:     n3TEID + i,
 			ctrID:     i,
 			farID:     n3,
 			needDecap: 1,

--- a/pfcpiface/upf.go
+++ b/pfcpiface/upf.go
@@ -6,6 +6,7 @@ package main
 import (
 	"context"
 	"log"
+	"math"
 	"net"
 	"time"
 
@@ -163,7 +164,7 @@ func (u *upf) sim(method string) {
 			srcIfaceMask: 0xFF,
 			dstIPMask:    0xFFFFFFFF,
 
-			precedence: 10,
+			precedence: 255,
 
 			fseID:     n3TEID + i,
 			ctrID:     i,
@@ -180,7 +181,7 @@ func (u *upf) sim(method string) {
 			tunnelTEIDMask:   0xFFFFFFFF,
 			tunnelIP4DstMask: 0xFFFFFFFF,
 
-			precedence: 20,
+			precedence: 1,
 
 			fseID:     n3TEID + i,
 			ctrID:     i,
@@ -200,7 +201,7 @@ func (u *upf) sim(method string) {
 			tunnelTEIDMask:   0xFFFFFFFF,
 			srcIPMask:        0xFFFFFFFF,
 
-			precedence: 10,
+			precedence: 255,
 
 			fseID:     n3TEID + i,
 			ctrID:     i,
@@ -219,7 +220,7 @@ func (u *upf) sim(method string) {
 			tunnelTEIDMask:   0xFFFFFFFF,
 			dstIPMask:        0xFFFFFFFF,
 
-			precedence: 20,
+			precedence: 1,
 
 			fseID:     n3TEID + i,
 			ctrID:     i,
@@ -428,7 +429,7 @@ func (u *upf) addPDR(ctx context.Context, done chan<- bool, p pdr) {
 
 		f := &pb.WildcardMatchCommandAddArg{
 			Gate:     uint64(p.needDecap),
-			Priority: int64(p.precedence),
+			Priority: int64(math.MaxUint32 - p.precedence),
 			Values: []*pb.FieldData{
 				intEnc(uint64(p.srcIface)),     /* src_iface */
 				intEnc(uint64(p.tunnelIP4Dst)), /* tunnel_ipv4_dst */

--- a/pfcpiface/utils.go
+++ b/pfcpiface/utils.go
@@ -27,6 +27,12 @@ func hex2int(hexStr string) uint32 {
 	return uint32(result)
 }
 
+func int2ip(nn uint32) net.IP {
+	ip := make(net.IP, 4)
+	binary.BigEndian.PutUint32(ip, nn)
+	return ip
+}
+
 func getOutboundIP(dstIP string) net.IP {
 	conn, err := net.Dial("udp", dstIP+":"+PFCPPort)
 	if err != nil {

--- a/pfcpiface/utils.go
+++ b/pfcpiface/utils.go
@@ -18,6 +18,13 @@ func ip2int(ip net.IP) uint32 {
 	return binary.BigEndian.Uint32(ip)
 }
 
+func ipMask2int(ip net.IPMask) uint32 {
+	if len(ip) == 16 {
+		return binary.BigEndian.Uint32(ip[12:16])
+	}
+	return binary.BigEndian.Uint32(ip)
+}
+
 func hex2int(hexStr string) uint32 {
 	// remove 0x suffix if found in the input string
 	cleaned := strings.Replace(hexStr, "0x", "", -1)


### PR DESCRIPTION
Certain flows of a session can be directed to N9 vs N6 based on SDF rules in PDI.
We now take leverage precedence field of wildcardmatch table too.
Swapped layout of dst/src ip ports to be consistent everywhere.