### PR TITLE
UPF initiated connection

### DIFF
--- a/pfcpiface/main.go
+++ b/pfcpiface/main.go
@@ -160,7 +160,9 @@ func main() {
 
 	if conf.CPIface.SrcIP == "" {
 		if conf.CPIface.DestIP != "" {
-			n4SrcIP = getOutboundIP(conf.CPIface.DestIP)
+			log.Println("Dest address ", conf.CPIface.DestIP)
+			n4SrcIP = getLocalIP(conf.CPIface.DestIP)
+			log.Println("SPGWU/UPF address IP: ", n4SrcIP.String())
 		}
 	} else {
 		addrs, err := net.LookupHost(conf.CPIface.SrcIP)
@@ -169,9 +171,9 @@ func main() {
 		}
 	}
 
-	log.Println("N4 IP: ", n4SrcIP.String())
+	log.Println("N4 local IP: ", n4SrcIP.String())
 
-	go pfcpifaceMainLoop(upf, accessIP.String(), coreIP.String(), n4SrcIP.String())
+	go pfcpifaceMainLoop(upf, accessIP.String(), coreIP.String(), n4SrcIP.String(), conf.CPIface.DestIP)
 
 	setupProm(upf)
 	log.Fatal(http.ListenAndServe(*httpAddr, nil))

--- a/pfcpiface/utils.go
+++ b/pfcpiface/utils.go
@@ -40,15 +40,25 @@ func int2ip(nn uint32) net.IP {
 	return ip
 }
 
-func getOutboundIP(dstIP string) net.IP {
+func getRemoteIP(dstIP string) net.IP {
+	conn, err := net.Dial("udp", dstIP+":"+PFCPPort)
+	if err != nil {
+		ip := "0.0.0.0"
+		return net.ParseIP(ip)
+	}
+	defer conn.Close()
+	remoteAddr := conn.RemoteAddr().(*net.UDPAddr)
+
+	return remoteAddr.IP
+}
+
+func getLocalIP(dstIP string) net.IP {
 	conn, err := net.Dial("udp", dstIP+":"+PFCPPort)
 	if err != nil {
 		log.Fatal(err)
 	}
 	defer conn.Close()
-
 	localAddr := conn.LocalAddr().(*net.UDPAddr)
-
 	return localAddr.IP
 }
 


### PR DESCRIPTION
Tested following cases
1. UPF connecting to SMF success case
2. Failure case or no response , UPF keep trying for connection
3. While connection is up, if Control plane is restarted then UPF sees socket timeout and this triggers the PFCP connection retry. For brief period of time, UPF not able to get the address of SMF/SPGWC, in that time retry is skipped, but as soon as address to pod is available connection is initiated.