### PR TITLE
Always populate sim info in upf struct

### DIFF
--- a/pfcpiface/bess_pb/bess_msg.pb.go
+++ b/pfcpiface/bess_pb/bess_msg.pb.go
@@ -44,7 +44,6 @@
 package bess_pb
 
 import (
-	proto "github.com/golang/protobuf/proto"
 	any "github.com/golang/protobuf/ptypes/any"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
@@ -58,10 +57,6 @@ const (
 	// Verify that runtime/protoimpl is sufficiently up-to-date.
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
-
-// This is a compile-time assertion that a sufficiently up-to-date version
-// of the legacy proto package is being used.
-const _ = proto.ProtoPackageIsVersion4
 
 type EmptyRequest struct {
 	state         protoimpl.MessageState

--- a/pfcpiface/bess_pb/error.pb.go
+++ b/pfcpiface/bess_pb/error.pb.go
@@ -36,7 +36,6 @@
 package bess_pb
 
 import (
-	proto "github.com/golang/protobuf/proto"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
@@ -49,10 +48,6 @@ const (
 	// Verify that runtime/protoimpl is sufficiently up-to-date.
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
-
-// This is a compile-time assertion that a sufficiently up-to-date version
-// of the legacy proto package is being used.
-const _ = proto.ProtoPackageIsVersion4
 
 type Error struct {
 	state         protoimpl.MessageState

--- a/pfcpiface/bess_pb/module_msg.pb.go
+++ b/pfcpiface/bess_pb/module_msg.pb.go
@@ -37,7 +37,6 @@
 package bess_pb
 
 import (
-	proto "github.com/golang/protobuf/proto"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
@@ -50,10 +49,6 @@ const (
 	// Verify that runtime/protoimpl is sufficiently up-to-date.
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
-
-// This is a compile-time assertion that a sufficiently up-to-date version
-// of the legacy proto package is being used.
-const _ = proto.ProtoPackageIsVersion4
 
 type EmptyArg struct {
 	state         protoimpl.MessageState

--- a/pfcpiface/bess_pb/ports/port_msg.pb.go
+++ b/pfcpiface/bess_pb/ports/port_msg.pb.go
@@ -36,7 +36,6 @@
 package bess_pb
 
 import (
-	proto "github.com/golang/protobuf/proto"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
@@ -49,10 +48,6 @@ const (
 	// Verify that runtime/protoimpl is sufficiently up-to-date.
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
-
-// This is a compile-time assertion that a sufficiently up-to-date version
-// of the legacy proto package is being used.
-const _ = proto.ProtoPackageIsVersion4
 
 type PCAPPortArg struct {
 	state         protoimpl.MessageState

--- a/pfcpiface/bess_pb/service.pb.go
+++ b/pfcpiface/bess_pb/service.pb.go
@@ -37,7 +37,6 @@ package bess_pb
 
 import (
 	context "context"
-	proto "github.com/golang/protobuf/proto"
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
@@ -52,10 +51,6 @@ const (
 	// Verify that runtime/protoimpl is sufficiently up-to-date.
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
-
-// This is a compile-time assertion that a sufficiently up-to-date version
-// of the legacy proto package is being used.
-const _ = proto.ProtoPackageIsVersion4
 
 var File_service_proto protoreflect.FileDescriptor
 

--- a/pfcpiface/bess_pb/util_msg.pb.go
+++ b/pfcpiface/bess_pb/util_msg.pb.go
@@ -36,7 +36,6 @@
 package bess_pb
 
 import (
-	proto "github.com/golang/protobuf/proto"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
@@ -49,10 +48,6 @@ const (
 	// Verify that runtime/protoimpl is sufficiently up-to-date.
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
-
-// This is a compile-time assertion that a sufficiently up-to-date version
-// of the legacy proto package is being used.
-const _ = proto.ProtoPackageIsVersion4
 
 /// The Field message represents one field in a packet -- either stored in metadata or in the packet body.
 type Field struct {

--- a/pfcpiface/main.go
+++ b/pfcpiface/main.go
@@ -132,11 +132,6 @@ func main() {
 	}
 	defer conn.Close()
 
-	var simInfo *SimModeInfo
-	if conf.Mode == modeSim {
-		simInfo = &conf.SimInfo
-	}
-
 	upf := &upf{
 		accessIface: conf.AccessIface.IfName,
 		coreIface:   conf.CoreIface.IfName,
@@ -145,7 +140,7 @@ func main() {
 		fqdnHost:    fqdnh,
 		client:      pb.NewBESSControlClient(conn),
 		maxSessions: conf.MaxSessions,
-		simInfo:     simInfo,
+		simInfo:     &conf.SimInfo,
 	}
 
 	if *simulate != "" {


### PR DESCRIPTION
This should ease the testing of DPDK mode with simulated sessions. Previously you would need to change the mode in json from dpdk to sim in order to insert session entries in the fastpath.

Signed-off-by: Saikrishna Edupuganti saikrishna.edupuganti@intel.com