### PR TITLE
BESS: fix checksum offload in bess patch

### DIFF
--- a/patches/bess/0010-Add-hardware-rx-checksum-offload-option-for-checksum.patch
+++ b/patches/bess/0010-Add-hardware-rx-checksum-offload-option-for-checksum.patch
@@ -1,4 +1,4 @@
-From 03933f03ba42b80c9a879b0c32c3ce575a686090 Mon Sep 17 00:00:00 2001
+From 6c482f00a9ad08088ba3957a58f1651f4e374d25 Mon Sep 17 00:00:00 2001
 From: Muhammad Asim Jamshed <muhammad.jamshed@intel.com>
 Date: Fri, 17 Jul 2020 17:19:11 -0700
 Subject: [PATCH] Add hardware rx checksum offload option for checksum.
@@ -7,12 +7,12 @@ Signed-off-by: Muhammad Asim Jamshed <muhammad.jamshed@intel.com>
 ---
  core/modules/ip_checksum.cc | 17 ++++++++++++++---
  core/modules/ip_checksum.h  |  6 +++++-
- core/modules/l4_checksum.cc | 34 +++++++++++++++++++++++++---------
+ core/modules/l4_checksum.cc | 43 ++++++++++++++++++++++++++++++++++---------
  core/modules/l4_checksum.h  |  5 ++++-
- 4 files changed, 48 insertions(+), 14 deletions(-)
+ 4 files changed, 57 insertions(+), 14 deletions(-)
 
 diff --git a/core/modules/ip_checksum.cc b/core/modules/ip_checksum.cc
-index ecaba24d..47f86bae 100644
+index ecaba24..47f86ba 100644
 --- a/core/modules/ip_checksum.cc
 +++ b/core/modules/ip_checksum.cc
 @@ -56,8 +56,8 @@ void IPChecksum::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
@@ -54,7 +54,7 @@ index ecaba24d..47f86bae 100644
  }
  
 diff --git a/core/modules/ip_checksum.h b/core/modules/ip_checksum.h
-index f0f1d079..94e0d724 100644
+index f0f1d07..94e0d72 100644
 --- a/core/modules/ip_checksum.h
 +++ b/core/modules/ip_checksum.h
 @@ -37,7 +37,9 @@
@@ -78,18 +78,27 @@ index f0f1d079..94e0d724 100644
  
  #endif  // BESS_MODULES_IP_CHECKSUM_H_
 diff --git a/core/modules/l4_checksum.cc b/core/modules/l4_checksum.cc
-index 3ad1f23d..127a5344 100644
+index 3ad1f23..20faa85 100644
 --- a/core/modules/l4_checksum.cc
 +++ b/core/modules/l4_checksum.cc
-@@ -63,27 +63,43 @@ void L4Checksum::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
+@@ -63,27 +63,52 @@ void L4Checksum::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
        Udp *udp =
            reinterpret_cast<Udp *>(reinterpret_cast<uint8_t *>(ip) + ip_bytes);
        if (verify_) {
 -	EmitPacket(ctx, batch->pkts()[i],
 -		   (VerifyIpv4UdpChecksum(*ip, *udp)) ? FORWARD_GATE : FAIL_GATE);
-+        EmitPacket(
-+            ctx, batch->pkts()[i],
-+            (VerifyIpv4UdpChecksum(*ip, *udp)) ? FORWARD_GATE : FAIL_GATE);
++        if (hw_) {
++          struct rte_mbuf *m = (struct rte_mbuf *)batch->pkts()[i];
++          if (unlikely((m->ol_flags & PKT_RX_L4_CKSUM_MASK) ==
++                       PKT_RX_L4_CKSUM_BAD))
++            EmitPacket(ctx, (bess::Packet *)m, FAIL_GATE);
++          else
++            EmitPacket(ctx, (bess::Packet *)m, FORWARD_GATE);
++        } else {
++          EmitPacket(
++              ctx, batch->pkts()[i],
++              (VerifyIpv4UdpChecksum(*ip, *udp)) ? FORWARD_GATE : FAIL_GATE);
++        }
        } else {
 -	udp->checksum = CalculateIpv4UdpChecksum(*ip, *udp);
 -	EmitPacket(ctx, batch->pkts()[i], FORWARD_GATE);
@@ -130,12 +139,12 @@ index 3ad1f23d..127a5344 100644
  
  CommandResponse L4Checksum::Init(const bess::pb::L4ChecksumArg &arg) {
    verify_ = arg.verify();
-+  hw_ = arg.verify();
++  hw_ = arg.hw();
    return CommandSuccess();
  }
  
 diff --git a/core/modules/l4_checksum.h b/core/modules/l4_checksum.h
-index 27ab8f98..56d8ae5c 100644
+index 27ab8f9..56d8ae5 100644
 --- a/core/modules/l4_checksum.h
 +++ b/core/modules/l4_checksum.h
 @@ -36,7 +36,9 @@
@@ -158,5 +167,5 @@ index 27ab8f98..56d8ae5c 100644
  
  #endif  // BESS_MODULES_L4_CHECKSUM_H_
 -- 
-2.17.1
+2.7.4
 


### PR DESCRIPTION
This commit enables the UDP rx checksum which was missing
in previous BESS patch.
It also fixes the hw_ inilization value.