### PR TITLE
UE ip pool allocation by UPF

### DIFF
--- a/conf/upf.json
+++ b/conf/upf.json
@@ -53,9 +53,11 @@
     
     "": "Control plane controller settings",
     "cpiface": {
-	"nb_dst_ip": "172.17.0.1",
-	"" : "nb_dst_ip: CPHostname",
-	"hostname": "spgwc"
+        "enable_ue_ip_alloc": false,
+        "ue_ip_pool": "10.250.0.0/16",
+        "nb_dst_ip": "172.17.0.1",
+        "" : "nb_dst_ip: CPHostname",
+	    "hostname": "spgwc"
     },
     
     "": "p4rtc interface settings",

--- a/pfcpiface/conn.go
+++ b/pfcpiface/conn.go
@@ -69,6 +69,9 @@ func pfcpifaceMainLoop(upf *upf, accessIP, coreIP, sourceIP, smfName string) {
 
 	// cleanup the pipeline
 	cleanupSessions := func() {
+		if upf.simInfo != nil {
+			return
+		}
 		sendDeleteAllSessionsMsgtoUPF(upf)
 		cpConnected = false
 	}

--- a/pfcpiface/go.mod
+++ b/pfcpiface/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.2.2
 	github.com/p4lang/p4runtime v1.3.0
 	github.com/prometheus/client_golang v1.9.0
-	github.com/wmnsk/go-pfcp v0.0.8
+	github.com/wmnsk/go-pfcp v0.0.9-0.20210129064645-e1b1f34ebd9f
 	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013
 	google.golang.org/grpc v1.35.0
 	google.golang.org/protobuf v1.25.0

--- a/pfcpiface/go.sum
+++ b/pfcpiface/go.sum
@@ -288,8 +288,8 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
-github.com/wmnsk/go-pfcp v0.0.8 h1:H/PDw2gvoYmXu3vltuIuJlckytUMpef4fAxl/ij2o64=
-github.com/wmnsk/go-pfcp v0.0.8/go.mod h1:Hwc6b/KmDF6tGa5hwhP5UGfKgwnL2CICFs3PgFz5cRE=
+github.com/wmnsk/go-pfcp v0.0.9-0.20210129064645-e1b1f34ebd9f h1:eof2jcYxj5zXKwR012IIeZ+odMCUMX/P+Oc163Ec6/s=
+github.com/wmnsk/go-pfcp v0.0.9-0.20210129064645-e1b1f34ebd9f/go.mod h1:Hwc6b/KmDF6tGa5hwhP5UGfKgwnL2CICFs3PgFz5cRE=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mIZCrds/GIG4ncV9HhK5PX7jPg=

--- a/pfcpiface/ip_pool.go
+++ b/pfcpiface/ip_pool.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2021-present Open Networking Foundation
+
+package main
+
+import (
+	"errors"
+	"log"
+	"net"
+)
+
+type ipPool struct {
+	freePool []string
+}
+
+func (ipp *ipPool) deallocIPV4(element net.IP) {
+	ipp.freePool = append(ipp.freePool, element.String()) // Simply append to enqueue.
+	log.Println("Enqueued:", element.String())
+}
+
+func (ipp *ipPool) allocIPV4() (net.IP, error) {
+	if len(ipp.freePool) == 0 {
+		err := errors.New("ip pool empty")
+		return nil, err
+	}
+	element := ipp.freePool[0] // The first element is the one to be dequeued.
+	log.Println("Dequeued:", element)
+	ipp.freePool = ipp.freePool[1:] // Slice off the element once it is dequeued.
+	ipVal := net.ParseIP(element).To4()
+	return ipVal, nil
+}
+
+func (ipp *ipPool) initPool(cidr string) error {
+	ip, ipnet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return err
+	}
+
+	for ip := ip.Mask(ipnet.Mask); ipnet.Contains(ip); inc(ip) {
+		ipp.freePool = append(ipp.freePool, ip.String())
+	}
+	// remove network address and broadcast address
+
+	ipp.freePool = ipp.freePool[1 : len(ipp.freePool)-1]
+	return nil
+}

--- a/pfcpiface/main.go
+++ b/pfcpiface/main.go
@@ -52,9 +52,11 @@ type SimModeInfo struct {
 
 // CPIfaceInfo : CPIface interface settings
 type CPIfaceInfo struct {
-	DestIP   string `json:"nb_dst_ip"`
-	SrcIP    string `json:"nb_src_ip"`
-	FQDNHost string `json:"hostname"`
+	DestIP          string `json:"nb_dst_ip"`
+	SrcIP           string `json:"nb_src_ip"`
+	FQDNHost        string `json:"hostname"`
+	EnableUeIPAlloc bool   `json:"enable_ue_ip_alloc"`
+	UeIPPool        string `json:"ue_ip_pool"`
 }
 
 // IfaceType : Gateway interface struct
@@ -139,11 +141,12 @@ func main() {
 	}
 
 	upf := &upf{
-		accessIface: conf.AccessIface.IfName,
-		coreIface:   conf.CoreIface.IfName,
-		fqdnHost:    fqdnh,
-		maxSessions: conf.MaxSessions,
-		intf:        intf,
+		accessIface:     conf.AccessIface.IfName,
+		coreIface:       conf.CoreIface.IfName,
+		fqdnHost:        fqdnh,
+		maxSessions:     conf.MaxSessions,
+		intf:            intf,
+		enableUeIPAlloc: conf.CPIface.EnableUeIPAlloc,
 	}
 
 	upf.setUpfInfo(&conf)

--- a/pfcpiface/p4rt.go
+++ b/pfcpiface/p4rt.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright(c) 2020 Intel Corporation
+// Copyright 2021-present Open Networking Foundation
 
 package main
 
@@ -217,23 +217,23 @@ func initCounter(p *p4rtc) error {
 
 func (p *p4rtc) isConnected(accessIP *net.IP) bool {
 	var errin error
-	if p.p4client == nil || p.p4client.CheckStatus() != Ready {
+	if p.p4client == nil {
 		p.p4client, errin = p.channelSetup()
 		if errin != nil {
 			log.Println("create channel failed : ", errin)
 			return false
-		} else {
-			if accessIP != nil {
-				*accessIP = p.accessIP
-			}
-			errin = p.p4client.ClearPdrTable()
-			if errin != nil {
-				log.Println("clear PDR table failed : ", errin)
-			}
-			errin = p.p4client.ClearFarTable()
-			if errin != nil {
-				log.Println("clear FAR table failed : ", errin)
-			}
+		}
+
+		if accessIP != nil {
+			*accessIP = p.accessIP
+		}
+		errin = p.p4client.ClearPdrTable()
+		if errin != nil {
+			log.Println("clear PDR table failed : ", errin)
+		}
+		errin = p.p4client.ClearFarTable()
+		if errin != nil {
+			log.Println("clear FAR table failed : ", errin)
 		}
 
 		errin = initCounter(p)

--- a/pfcpiface/p4rtc.go
+++ b/pfcpiface/p4rtc.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2021-present Open Networking Foundation
+
 package main
 
 import (
@@ -277,7 +280,7 @@ func (c *P4rtClient) WriteFarTable(
 		te.Params[7].Value[0] = val[0]
 	}
 
-	var prio int32 = 0
+	var prio int32
 	return c.InsertTableEntry(te, funcType, prio)
 }
 
@@ -297,7 +300,7 @@ func (c *P4rtClient) WritePdrTable(
 	te.Fields[0].Name = "src_iface"
 	enumName := "InterfaceType"
 	var srcIntfStr string
-	var decapVal uint8 = 0
+	var decapVal uint8
 	if pdrEntry.srcIface == access {
 		srcIntfStr = "ACCESS"
 		decapVal = 1
@@ -402,7 +405,7 @@ func (c *P4rtClient) WriteInterfaceTable(
 	}
 	te.Params[1].Value = val
 
-	var prio int32 = 0
+	var prio int32
 	return c.InsertTableEntry(te, funcType, prio)
 }
 
@@ -432,9 +435,9 @@ func (c *P4rtClient) getFieldValue(entity *p4.Entity,
 		return nil, err
 	}
 
-	var matchType p4ConfigV1.MatchField_MatchType = 0
-	var fieldID uint32 = 0
-	var paramID uint32 = 0
+	var matchType p4ConfigV1.MatchField_MatchType
+	var fieldID uint32
+	var paramID uint32
 	for _, tables := range c.P4Info.Tables {
 		if tables.Preamble.Id == tableID {
 			for _, fields := range tables.MatchFields {
@@ -670,7 +673,7 @@ func (c *P4rtClient) ClearFarTable() error {
 		TableName: "PreQosPipe.load_far_attributes",
 	}
 
-	var prio int32 = 0
+	var prio int32
 	readRes, err := c.ReadTableEntry(te, prio)
 	if err != nil {
 		log.Println("Read Interface table failed ", err)
@@ -702,7 +705,7 @@ func (c *P4rtClient) ClearPdrTable() error {
 		TableName: "PreQosPipe.pdrs",
 	}
 
-	var prio int32 = 0
+	var prio int32
 	readRes, err := c.ReadTableEntry(te, prio)
 	if err != nil {
 		log.Println("Read Pdr table failed ", err)
@@ -760,7 +763,7 @@ func (c *P4rtClient) ReadInterfaceTable(
 	}
 	te.Params[1].Value = val
 
-	var prio int32 = 0
+	var prio int32
 	readRes, err := c.ReadTableEntry(te, prio)
 	if err != nil {
 		log.Println("Read Interface table failed ", err)
@@ -785,7 +788,7 @@ func (c *P4rtClient) ReadInterfaceTable(
 	return err
 }
 
-//ReadTableEntry .. Read table Entry
+//ReadTableEntry ... Read table Entry
 func (c *P4rtClient) ReadTableEntry(
 	tableEntry AppTableEntry, prio int32) (*p4.ReadResponse, error) {
 
@@ -804,6 +807,7 @@ func (c *P4rtClient) ReadTableEntry(
 	return c.ReadReq(entity)
 }
 
+//ReadReqEntities ... Read request Entity
 func (c *P4rtClient) ReadReqEntities(entities []*p4.Entity) (*p4.ReadResponse, error) {
 	req := &p4.ReadRequest{
 		DeviceId: c.DeviceID,
@@ -916,6 +920,7 @@ func (c *P4rtClient) WriteReq(update *p4.Update) error {
 	return err
 }
 
+// GetForwardingPipelineConfig ... Get Pipeline config from switch
 func (c *P4rtClient) GetForwardingPipelineConfig() (err error) {
 	log.Println("GetForwardingPipelineConfig")
 	pipeline, err := GetPipelineConfig(c.Client, c.DeviceID)
@@ -928,7 +933,7 @@ func (c *P4rtClient) GetForwardingPipelineConfig() (err error) {
 	return
 }
 
-// SetPipelineConfig ... Set pipeline config
+// GetPipelineConfig ... Set pipeline config
 func GetPipelineConfig(client p4.P4RuntimeClient, deviceID uint64) (*p4.GetForwardingPipelineConfigResponse, error) {
 	req := &p4.GetForwardingPipelineConfigRequest{
 		DeviceId:     deviceID,

--- a/pfcpiface/parse-far.go
+++ b/pfcpiface/parse-far.go
@@ -13,15 +13,21 @@ import (
 type operation int
 
 const (
-	FwdIE_OuterHeaderCreation Bits = 1 << iota
-	FwdIE_DestinationIntf
+	//FwdIEOuterHeaderCreation ...
+	FwdIEOuterHeaderCreation Bits = 1 << iota
+	//FwdIEDestinationIntf ...
+	FwdIEDestinationIntf
 )
 
 const (
-	Action_Forward = 0x2
-	Action_Drop    = 0x1
-	Action_Buffer  = 0x4
-	Action_Notify  = 0x8
+	//ActionForward ...
+	ActionForward = 0x2
+	//ActionDrop ...
+	ActionDrop = 0x1
+	//ActionBuffer ...
+	ActionBuffer = 0x4
+	//ActionNotify ...
+	ActionNotify = 0x8
 )
 
 const (
@@ -59,27 +65,21 @@ func (f *far) printFAR() {
 }
 
 func (f *far) setActionValue() uint8 {
-	if (f.applyAction & Action_Forward) != 0 {
+	if (f.applyAction & ActionForward) != 0 {
 		if f.dstIntf == ie.DstInterfaceAccess {
-			log.Println("Set Action forwardD")
 			return farForwardD
 		} else if f.dstIntf == ie.DstInterfaceCore {
-			log.Println("Set Action forwardU")
 			return farForwardU
 		}
-	} else if (f.applyAction & Action_Drop) != 0 {
-		log.Println("Set Action drop")
+	} else if (f.applyAction & ActionDrop) != 0 {
 		return farDrop
-	} else if (f.applyAction & Action_Buffer) != 0 {
-		log.Println("Set Action buffer")
+	} else if (f.applyAction & ActionBuffer) != 0 {
 		return farBuffer
-	} else if (f.applyAction & Action_Notify) != 0 {
-		log.Println("Set Action notify")
+	} else if (f.applyAction & ActionNotify) != 0 {
 		return farNotify
 	}
 
 	//default action
-	log.Println("Set Action drop default")
 	return farDrop
 }
 
@@ -117,7 +117,7 @@ func (f *far) parseFAR(farIE *ie.IE, fseid uint64, upf *upf, op operation) error
 	for _, fwdIE := range fwdIEs {
 		switch fwdIE.Type {
 		case ie.OuterHeaderCreation:
-			fields = Set(fields, FwdIE_OuterHeaderCreation)
+			fields = Set(fields, FwdIEOuterHeaderCreation)
 			ohcFields, err := fwdIE.OuterHeaderCreation()
 			if err != nil {
 				log.Println("Unable to parse OuterHeaderCreationFields!")
@@ -128,7 +128,7 @@ func (f *far) parseFAR(farIE *ie.IE, fseid uint64, upf *upf, op operation) error
 			f.tunnelType = uint8(1)
 			f.tunnelPort = tunnelGTPUPort
 		case ie.DestinationInterface:
-			fields = Set(fields, FwdIE_DestinationIntf)
+			fields = Set(fields, FwdIEDestinationIntf)
 			f.dstIntf, err = fwdIE.DestinationInterface()
 			if err != nil {
 				log.Println("Unable to parse DestinationInterface field")

--- a/pfcpiface/pfcpsim.go
+++ b/pfcpiface/pfcpsim.go
@@ -15,7 +15,7 @@ import (
 
 func createPFCP(conn *net.UDPConn, raddr *net.UDPAddr) uint64 {
 	{
-		var seq uint32 = 0
+		var seq uint32
 		hbreq, err := message.NewHeartbeatRequest(
 			seq,
 			ie.NewRecoveryTimeStamp(time.Now()),

--- a/pfcpiface/session-pdr.go
+++ b/pfcpiface/session-pdr.go
@@ -5,7 +5,41 @@ package main
 
 import (
 	"errors"
+	"github.com/wmnsk/go-pfcp/ie"
+	"github.com/wmnsk/go-pfcp/message"
+	"log"
+	"net"
 )
+
+// Release allocated IPs
+func releaseAllocatedIPs(upf *upf, session *PFCPSession) {
+	log.Println("release allocated IPs")
+	for _, pdr := range session.pdrs {
+		if (pdr.allocIPFlag) && (pdr.srcIface == core) {
+			var ueIP net.IP = int2ip(pdr.dstIP)
+			log.Println("pdrID : ", pdr.pdrID, ", ueIP : ", ueIP.String())
+			upf.ippool.deallocIPV4(ueIP)
+		}
+	}
+}
+
+func addPdrInfo(msg *message.SessionEstablishmentResponse,
+	session *PFCPSession) {
+	log.Println("Add PDRs with UPF alloc IPs to Establishment response")
+	for _, pdr := range session.pdrs {
+		if (pdr.allocIPFlag) && (pdr.srcIface == core) {
+			log.Println("pdrID : ", pdr.pdrID)
+			var flags uint8 = 0x02
+			var ueIP net.IP = int2ip(pdr.dstIP)
+			log.Println("ueIP : ", ueIP.String())
+			msg.CreatedPDR = append(msg.CreatedPDR,
+				ie.NewCreatedPDR(
+					ie.NewPDRID(uint16(pdr.pdrID)),
+					ie.NewUEIPAddress(flags, ueIP.String(), "", 0, 0),
+				))
+		}
+	}
+}
 
 // CreatePDR appends pdr to existing list of PDRs in the session
 func (s *PFCPSession) CreatePDR(p pdr) {

--- a/pfcpiface/upf.go
+++ b/pfcpiface/upf.go
@@ -8,15 +8,18 @@ import (
 )
 
 type upf struct {
-	accessIface string
-	coreIface   string
-	accessIP    net.IP
-	coreIP      net.IP
-	n4SrcIP     net.IP
-	fqdnHost    string
-	maxSessions uint32
-	simInfo     *SimModeInfo
-	intf        fastPath
+	enableUeIPAlloc bool
+	accessIface     string
+	coreIface       string
+	ippoolCidr      string
+	accessIP        net.IP
+	coreIP          net.IP
+	n4SrcIP         net.IP
+	fqdnHost        string
+	maxSessions     uint32
+	simInfo         *SimModeInfo
+	intf            fastPath
+	ippool          ipPool
 }
 
 // to be replaced with go-pfcp structs

--- a/pfcpiface/utils.go
+++ b/pfcpiface/utils.go
@@ -16,13 +16,37 @@ const (
 	Ready = 2 //grpc channel state Ready
 )
 
+// Bits type
 type Bits uint8
 
+// Set Bits
 func Set(b, flag Bits) Bits { return b | flag }
 
 //func Clear(b, flag Bits) Bits  { return b &^ flag }
 //func Toggle(b, flag Bits) Bits { return b ^ flag }
 //func Has(b, flag Bits) bool { return b&flag != 0 }
+func setUeipFeature(features ...uint8) {
+	if len(features) >= 3 {
+		features[2] = features[2] | 0x04
+	}
+}
+
+func has2ndBit(f uint8) bool {
+	return (f&0x02)>>1 == 1
+}
+
+func has5thBit(f uint8) bool {
+	return (f & 0x010) == 1
+}
+
+func inc(ip net.IP) {
+	for j := len(ip) - 1; j >= 0; j-- {
+		ip[j]++
+		if ip[j] > 0 {
+			break
+		}
+	}
+}
 
 func ip2int(ip net.IP) uint32 {
 	if len(ip) == 16 {

--- a/pfcpiface/vendor/github.com/wmnsk/go-pfcp/ie/ue-ip-address.go
+++ b/pfcpiface/vendor/github.com/wmnsk/go-pfcp/ie/ue-ip-address.go
@@ -192,7 +192,7 @@ func ParseUEIPAddressFields(b []byte) (*UEIPAddressFields, error) {
 // UnmarshalBinary parses b into IE.
 func (f *UEIPAddressFields) UnmarshalBinary(b []byte) error {
 	l := len(b)
-	if l < 2 {
+	if l < 1 {
 		return io.ErrUnexpectedEOF
 	}
 

--- a/pfcpiface/vendor/github.com/wmnsk/go-pfcp/message/misc.go
+++ b/pfcpiface/vendor/github.com/wmnsk/go-pfcp/message/misc.go
@@ -4,8 +4,6 @@
 
 package message
 
-import "encoding/hex"
-
 func uint24To32(b []byte) uint32 {
 	if len(b) != 3 {
 		return 0
@@ -17,34 +15,7 @@ func uint32To24(n uint32) []byte {
 	return []byte{uint8(n >> 16), uint8(n >> 8), uint8(n)}
 }
 
-func strToSwappedBytes(s, filler string) ([]byte, error) {
-	var raw []byte
-	var err error
-	if len(s)%2 == 0 {
-		raw, err = hex.DecodeString(s)
-	} else {
-		raw, err = hex.DecodeString(s + filler)
-	}
-	if err != nil {
-		return nil, err
-	}
-
-	return swap(raw), nil
-}
-
-func swappedBytesToStr(raw []byte, cutLastDigit bool) string {
-	if len(raw) == 0 {
-		return ""
-	}
-
-	s := hex.EncodeToString(swap(raw))
-	if cutLastDigit {
-		s = s[:len(s)-1]
-	}
-
-	return s
-}
-
+/*
 func swap(raw []byte) []byte {
 	var swapped []byte
 	for n := range raw {
@@ -73,6 +44,7 @@ func has5thBit(f uint8) bool {
 func has4thBit(f uint8) bool {
 	return (f&0x08)>>3 == 1
 }
+*/
 
 func has3rdBit(f uint8) bool {
 	return (f&0x04)>>2 == 1

--- a/pfcpiface/vendor/modules.txt
+++ b/pfcpiface/vendor/modules.txt
@@ -33,7 +33,7 @@ github.com/prometheus/common/model
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/wmnsk/go-pfcp v0.0.8
+# github.com/wmnsk/go-pfcp v0.0.9-0.20210129064645-e1b1f34ebd9f
 github.com/wmnsk/go-pfcp/ie
 github.com/wmnsk/go-pfcp/internal/logger
 github.com/wmnsk/go-pfcp/internal/utils


### PR DESCRIPTION
Changes include : 
1. config for ip pool and ip pool feature flag
2. send UPF features flag in Association response with UEIP flag.
3. alloc UE ip in case when upf supports this feature and smf has sent IP with only CHV4 flag.
4. send PDR with UE info in establishment response 