### PR TITLE
Use qout and more workers for pktgen

### DIFF
--- a/conf/pktgen.bess
+++ b/conf/pktgen.bess
@@ -1,6 +1,6 @@
 """
 docker run --name pktgen -td --restart unless-stopped \
-           --cpuset-cpus=15-16 --ulimit memlock=-1 --cap-add IPC_LOCK \
+           --cpuset-cpus=2-5 --ulimit memlock=-1 --cap-add IPC_LOCK \
            -v /dev/hugepages:/dev/hugepages -v "$PWD/conf":/opt/bess/bessctl/conf \
            --device=/dev/vfio/vfio --device=/dev/vfio/176 \
            upf-epc-bess:"$(<VERSION)" -grpc-url=0.0.0.0:10514
@@ -8,25 +8,47 @@ docker run --name pktgen -td --restart unless-stopped \
 
 import conf.sim as sim
 
+pkt_size = 128
+flows = 5000
+workers=[2, 3, 4, 5]
+
 # flow create 0 ingress pattern eth / ipv4 / udp / gtpu / ipv4 / end actions rss types ipv4 l3-src-only end key_len 0 queues end / end
-n39_pkts = [sim.gen_gtpu_packet(128, "22:53:7a:15:58:50", "9e:b2:d3:34:ab:27", "11.1.1.129", "198.18.0.1", "16.0.0.1", "9.9.9.9", 0x123456),]
-n36_pkts = [sim.gen_gtpu_packet(128, "22:53:7a:15:58:50", "9e:b2:d3:34:ab:27", "11.1.1.129", "198.18.0.1", "16.0.0.1", "6.6.6.6", 0x123456),]
+n39_pkts = [sim.gen_gtpu_packet(pkt_size, "22:53:7a:15:58:50", "9e:b2:d3:34:ab:27", "11.1.1.129", "198.18.0.1", "16.0.0.1", "9.9.9.9", 0x30000000),]
+n36_pkts = [sim.gen_gtpu_packet(pkt_size, "22:53:7a:15:58:50", "9e:b2:d3:34:ab:27", "11.1.1.129", "198.18.0.1", "16.0.0.1", "6.6.6.6", 0x30000000),]
 
 # flow create 1 ingress pattern eth / ipv4 / udp / gtpu / ipv4 / end actions rss types ipv4 l3-dst-only end key_len 0 queues end / end
-n9_pkts = [sim.gen_gtpu_packet(128, "22:53:7a:15:58:50", "c2:9c:55:d4:8a:f6", "13.1.1.199", "198.19.0.1", "9.9.9.9", "16.0.0.1", 0x123456),]
+n9_pkts = [sim.gen_gtpu_packet(pkt_size, "22:53:7a:15:58:50", "c2:9c:55:d4:8a:f6", "13.1.1.199", "198.19.0.1", "9.9.9.9", "16.0.0.1", 0x90000000),]
 
 #flow create 1 ingress pattern eth / ipv4 / end actions rss types ipv4 l3-dst-only end key_len 0 queues end / end
-n6_pkts = [sim.gen_inet_packet(128, "22:53:7a:15:58:50", "c2:9c:55:d4:8a:f6", "6.6.6.6", "16.0.0.1"),]
+n6_pkts = [sim.gen_inet_packet(pkt_size, "22:53:7a:15:58:50", "c2:9c:55:d4:8a:f6", "6.6.6.6", "16.0.0.1"),]
 
-p = PMDPort(port_id=0)
-pout::PortOut(port=p.name)
+for wid in range(len(workers)):
+    bess.add_worker(wid=wid, core=int(workers[wid % len(workers)]))
 
-n3seq_kwargs = sim.gen_gtpu_sequpdate_args(5000, "16.0.0.1", 62, 0x30000000)
-n9seq_kwargs = sim.gen_gtpu_sequpdate_args(5000, "16.0.0.1", 66, 0x90000000)
-n6seq_kwargs = sim.gen_inet_sequpdate_args(5000, "16.0.0.1")
+num_q = len(workers)
+kwargs = {'num_inc_q': num_q,
+          'num_out_q': num_q}
+p = PMDPort(port_id=0, **kwargs)
 
-Source() -> Rewrite(templates=n39_pkts) -> n39update::SequentialUpdate(**n3seq_kwargs) -> L4Checksum() -> IPChecksum() -> pout
-Source() -> Rewrite(templates=n36_pkts) -> n36update::SequentialUpdate(**n3seq_kwargs) -> L4Checksum() -> IPChecksum() -> pout
+n3seq_kwargs = sim.gen_gtpu_sequpdate_args(flows, "16.0.0.1", 62, 0x30000000)
+n9seq_kwargs = sim.gen_gtpu_sequpdate_args(flows, "16.0.0.1", 66, 0x90000000)
+n6seq_kwargs = sim.gen_inet_sequpdate_args(flows, "16.0.0.1")
 
-Source() -> Rewrite(templates=n9_pkts) -> n9update::SequentialUpdate(**n9seq_kwargs) -> L4Checksum() -> IPChecksum() -> pout
-Source() -> Rewrite(templates=n6_pkts) -> n6update::SequentialUpdate(**n6seq_kwargs) -> L4Checksum() -> IPChecksum() -> pout
+# 25 Gbps each to saturate 100 Gbps
+bess.add_tc('39_limit', wid=0, policy='rate_limit', resource='bit', limit={'bit': 25000000000})
+bess.add_tc('36_limit', wid=0, policy='rate_limit', resource='bit', limit={'bit': 25000000000})
+bess.add_tc('6_limit',  wid=1, policy='rate_limit', resource='bit', limit={'bit': 25000000000})
+bess.add_tc('9_limit',  wid=1, policy='rate_limit', resource='bit', limit={'bit': 25000000000})
+
+src39::Source(pkt_size=pkt_size) -> Rewrite(templates=n39_pkts) -> n39update::SequentialUpdate(**n3seq_kwargs) -> L4Checksum() -> IPChecksum() -> QueueOut(port=p.name, qid=0)
+src36::Source(pkt_size=pkt_size) -> Rewrite(templates=n36_pkts) -> n36update::SequentialUpdate(**n3seq_kwargs) -> L4Checksum() -> IPChecksum() -> QueueOut(port=p.name, qid=1)
+
+src9::Source(pkt_size=pkt_size) -> Rewrite(templates=n9_pkts) -> n9update::SequentialUpdate(**n9seq_kwargs) -> L4Checksum() -> IPChecksum() -> QueueOut(port=p.name, qid=2)
+src6::Source(pkt_size=pkt_size) -> Rewrite(templates=n6_pkts) -> n6update::SequentialUpdate(**n6seq_kwargs) -> L4Checksum() -> IPChecksum() -> QueueOut(port=p.name, qid=3)
+
+src39.attach_task(parent='39_limit')
+src36.attach_task(parent='36_limit')
+
+src9.attach_task(parent='9_limit')
+src6.attach_task(parent='6_limit')
+


### PR DESCRIPTION
Instead of using pout we now use qout which is explicit with the qid
We have bit limits of 25 Gbps for each type of traffic 50 UL/50 DL
We add more workers to push 100 Gbps for testing CVL

Signed-off-by: Saikrishna Edupuganti <saikrishna.edupuganti@intel.com>