### PR TITLE
Make the http port default value consistent

### DIFF
--- a/conf/upf.json
+++ b/conf/upf.json
@@ -64,7 +64,7 @@
         "nb_dst_ip": "172.17.0.1",
         "" : "nb_dst_ip: CPHostname",
         "hostname": "spgwc",
-        "prom_port": "8089"
+        "prom_port": "8080"
     },
     
     "": "p4rtc interface settings",


### PR DESCRIPTION
8080 has been used in couple of different places. Instead of changing all of those, changing the default value here.