### PR TITLE
Fix telemetry

### DIFF
--- a/conf/parser.py
+++ b/conf/parser.py
@@ -68,13 +68,13 @@ class Parser:
 
         # Enable hardware checksum
         try:
-            self.hwcksum = bool(self.conf["hwcksum"] == 'True' or self.conf["hwcksum"] == 'true')
+            self.hwcksum = bool(self.conf["hwcksum"])
         except KeyError:
             print('hwcksum not set, using default software fallback')
 
         # Enable DDP
         try:
-            self.ddp = bool(self.conf["ddp"] == 'True' or self.conf["ddp"] == 'true')
+            self.ddp = bool(self.conf["ddp"])
         except KeyError:
             print('ddp not set, using default software fallback')
 
@@ -82,7 +82,7 @@ class Parser:
         # See this link for details:
         # https://github.com/NetSys/bess/blob/master/bessctl/module_tests/timestamp.py
         try:
-            self.measure = bool(self.conf["measure"] == 'True' or self.conf["measure"] == 'true')
+            self.measure = self.conf["measure"]
         except KeyError:
             print('measure value not set. Not installing Measure module.')
 
@@ -142,6 +142,6 @@ class Parser:
 
         # Network Token Function
         try:
-            self.enable_ntf = bool(self.conf['enable_ntf'] == 'True' or self.conf['enable_ntf'] == 'true')
+            self.enable_ntf = bool(self.conf['enable_ntf'])
         except KeyError:
             print('Network Token Function disabled')

--- a/conf/upf.json
+++ b/conf/upf.json
@@ -29,10 +29,10 @@
     "": "ip_frag_with_eth_mtu: 1518",
 
     "": "Enable hardware offload of checksum. Might disable vector PMD",
-    "": "hwcksum: True",
+    "hwcksum": false,
 
     "": "Enable Intel Dynamic Device Personalization (DDP)",
-    "": "ddp: True",
+    "ddp": true,
 
     "": "Telemetrics-See this link for details: https://github.com/NetSys/bess/blob/master/bessctl/module_tests/timestamp.py",
     "measure": true,
@@ -64,7 +64,7 @@
         "nb_dst_ip": "172.17.0.1",
         "" : "nb_dst_ip: CPHostname",
         "hostname": "spgwc",
-        "prom_port": "8089"
+        "prom_port": "8080"
     },
     
     "": "p4rtc interface settings",

--- a/pfcpiface/bess.go
+++ b/pfcpiface/bess.go
@@ -153,11 +153,6 @@ func (b *bess) getPortStats(ifname string) *pb.GetPortStatsResponse {
 }
 
 func (b *bess) portStats(uc *upfCollector, ch chan<- prometheus.Metric) {
-	// When operating in sim mode there are no BESS ports
-	if uc.upf.simInfo != nil {
-		return
-	}
-
 	portstats := func(ifaceLabel, ifaceName string) {
 		packets := func(packets uint64, direction string) {
 			p := prometheus.MustNewConstMetric(


### PR DESCRIPTION
- Use json bool parsing properly
- Change default prom port in upf.json to 8080 to match prometheus.yml
- Remove check for simInfo when querying portStats

Signed-off-by: Saikrishna Edupuganti <saikrishna.edupuganti@intel.com>