### PR TITLE
Make ddp false by default

### DIFF
--- a/conf/upf.json
+++ b/conf/upf.json
@@ -32,7 +32,7 @@
     "hwcksum": false,
 
     "": "Enable Intel Dynamic Device Personalization (DDP)",
-    "ddp": true,
+    "ddp": false,
 
     "": "Telemetrics-See this link for details: https://github.com/NetSys/bess/blob/master/bessctl/module_tests/timestamp.py",
     "measure": true,


### PR DESCRIPTION
To make sure we do not error out for non-CVL (100G) users out of the box, keep the default as false in the config file.