### PR TITLE
Fix: pfcpsim connection refused

### DIFF
--- a/conf/upf.json
+++ b/conf/upf.json
@@ -68,7 +68,6 @@
     "cpiface": {
         "enable_ue_ip_alloc": false,
         "ue_ip_pool": "10.250.0.0/16",
-        "nb_dst_ip": "172.17.0.1",
         "" : "nb_dst_ip: CPHostname",
         "" : "hostname: upf",
         "prom_port": "8080",

--- a/pfcpiface/pfcpsim.go
+++ b/pfcpiface/pfcpsim.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"flag"
 	"log"
 	"net"
 	"time"
@@ -299,12 +298,7 @@ func deletePFCP(conn *net.UDPConn, raddr *net.UDPAddr, seid uint64) {
 }
 
 func pfcpSim() {
-	var (
-		server = flag.String("-s", "127.0.0.1:8805", "server's addr/port")
-	)
-	flag.Parse()
-
-	raddr, err := net.ResolveUDPAddr("udp", *server)
+	raddr, err := net.ResolveUDPAddr("udp", "127.0.0.1:"+PFCPPort)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -315,10 +309,10 @@ func pfcpSim() {
 	}
 
 	seid := createPFCP(conn, raddr)
-	time.Sleep(20 * time.Second)
+	time.Sleep(10 * time.Second)
 
 	modifyPFCP(conn, raddr, seid)
-	time.Sleep(20 * time.Second)
+	time.Sleep(10 * time.Second)
 
 	deletePFCP(conn, raddr, seid)
 


### PR DESCRIPTION
- Remove default config pointing to 172.17.0.1. UPF listens on 0.0.0.0
- Remove flag parsing from pfcpsim

Fixes: #256 

Signed-off-by: Saikrishna Edupuganti <saikrishna.edupuganti@intel.com>