### PR TITLE
Fix: Convert build-args to labels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,11 +35,12 @@ docker-build:
 		DOCKER_BUILDKIT=$(DOCKER_BUILDKIT) docker build --pull $(DOCKER_BUILD_ARGS) \
 			--target $$target \
 			--tag ${DOCKER_REGISTRY}${DOCKER_REPOSITORY}upf-epc-$$target:${DOCKER_TAG} \
-			--build-arg org_label_schema_version="${VERSION}" \
-			--build-arg org_label_schema_vcs_url="${DOCKER_LABEL_VCS_URL}" \
-			--build-arg org_label_schema_vcs_ref="${DOCKER_LABEL_VCS_REF}" \
-			--build-arg org_label_schema_build_date="${DOCKER_LABEL_BUILD_DATE}" \
-			--build-arg org_opencord_vcs_commit_date="${DOCKER_LABEL_COMMIT_DATE}" \
+			--label org.opencontainers.image.source="https://github.com/omec-project/upf-epc" \
+			--label org.label.schema.version="${VERSION}" \
+			--label org.label.schema.vcs.url="${DOCKER_LABEL_VCS_URL}" \
+			--label org.label.schema.vcs.ref="${DOCKER_LABEL_VCS_REF}" \
+			--label org.label.schema.build.date="${DOCKER_LABEL_BUILD_DATE}" \
+			--label org.opencord.vcs.commit.date="${DOCKER_LABEL_COMMIT_DATE}" \
 			. \
 			|| exit 1; \
 	done


### PR DESCRIPTION
To add to metadata of the docker image label arg is required

Signed-off-by: Saikrishna Edupuganti <saikrishna.edupuganti@intel.com>