### PR TITLE
base image weekly update instead of daily

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -6,7 +6,7 @@ name: BESS Build Base Image
 # or API.
 on:
   schedule:
-    - cron: '0 7 * * *'
+    - cron: '0 0 * * SUN'
   workflow_dispatch:
 jobs:
   build:


### PR DESCRIPTION
Change the update frequency of BESS build base image workflow to weekly. This will now run every sunday
https://crontab.guru/every-sunday