### PR TITLE
Move reassembly before BPF

### DIFF
--- a/conf/up4.bess
+++ b/conf/up4.bess
@@ -131,9 +131,9 @@ for idx, iface in enumerate(interfaces):
 
     # setup port module with auxiliary modules
     if parser.mode == 'sim':
-        p.setup_port(parser.ip_frag_with_eth_mtu, parser.measure, packet_generator[iface], **seq_kwargs[iface])
+        p.setup_port(parser.ip_frag_with_eth_mtu, parser.max_ip_defrag_flows, parser.measure, packet_generator[iface], **seq_kwargs[iface])
     else:
-        p.setup_port(parser.ip_frag_with_eth_mtu, parser.measure)
+        p.setup_port(parser.ip_frag_with_eth_mtu, parser.max_ip_defrag_flows, parser.measure)
 
     # Finally add entry to ports list
     ports[p.name] = p
@@ -260,14 +260,6 @@ if ports[parser.core_ifname].nat is not None:
     _in = ports[parser.core_ifname].nat
     gate = 0
 
-# Append coreIP4Defrag module (if enabled)
-if parser.max_ip_defrag_flows is not None:
-    _in:gate -> coreIP4Defrag::IPDefrag(num_flows=parser.max_ip_defrag_flows, numa=0)
-    _in = coreIP4Defrag
-    gate = 1
-    # Drop pkts that are unable to be fragmented
-    coreIP4Defrag:0 -> coreIP4DefragFail::Sink()
-
 # 2. Build the remaining first half of the DL pipeline before entering the shared pipeline
 #ports[parser.core_ifname].rewrite \
 _in:gate \
@@ -326,14 +318,6 @@ accessFastBPF:GTPUGate \
 # Record last module to chain up option modules
 _in = accessRxUDPCksum
 gate = 0
-
-# Append accessIP4Defrag module (if enabled)
-if parser.max_ip_defrag_flows is not None:
-    _in:gate ->accessIP4Defrag::IPDefrag(num_flows=parser.max_ip_defrag_flows, numa=0)
-    _in = accessIP4Defrag
-    gate = 1
-    # Drop pkts that are unable to be fragmented
-    accessIP4Defrag:0 -> accessIP4DefragFail::Sink()
 
 # 2. Build the remaining first half of the UL pipeline before entering the shard pipeline
 #ports[parser.access_ifname].rewrite \

--- a/pfcpiface/go.sum
+++ b/pfcpiface/go.sum
@@ -64,8 +64,6 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gopacket v1.1.19 h1:ves8RnFZPGiFnTS0uPQStjwru6uO6h+nlr9j6fL7kF8=
 github.com/google/gopacket v1.1.19/go.mod h1:iJ8V8n6KS+z2U1A8pUwu8bW5SyEMkXJB8Yo/Vo+TKTo=
-github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
-github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 h1:+9834+KizmvFV7pXQGSXQTsaWhq2GjuNUt0aUU0YBYw=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0/go.mod h1:z0ButlSOZa5vEBq9m2m2hlwIgKw+rp3sdCBRoJY+30Y=
@@ -147,9 +145,7 @@ golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
-golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
-golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
@@ -199,7 +195,6 @@ golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
-golang.org/x/tools v0.0.0-20200103221440-774c71fcf114/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=


### PR DESCRIPTION
Re-assembly is needed for tunneled and non tunneled packets. For
tunneled packets the IP fragments lost the tunnel details leading to
misclassification by the BPF towards the kernel. Moving this module
before BPF solves this issue. This is handled as part of setup port now.

Signed-off-by: Saikrishna Edupuganti <saikrishna.edupuganti@intel.com>