### PR TITLE
bess qer support

### DIFF
--- a/conf/up4.bess
+++ b/conf/up4.bess
@@ -27,6 +27,7 @@ farBufferAction = 3
 farNotifyCPAction = 4
 pdrFailGate = 2
 farFailGate = 2
+qerFailGate = 1
 interfaces = ["access", "core"]
 parser = Parser('conf/upf.json')
 parser.parse(interfaces)
@@ -183,6 +184,7 @@ linkMerge::Merge() \
                                 values=[{'attr_name':'pdr_id', 'num_bytes':4}, \
                                         {'attr_name':'fseid', 'num_bytes':8}, \
                                         {'attr_name':'ctr_id', 'num_bytes':4}, \
+                                        {'attr_name':'qer_id', 'num_bytes':4}, \
                                         {'attr_name':'far_id', 'num_bytes':4}]):noGTPUDecap \
     -> preQoSCounter::Counter(name_id='ctr_id', check_exist=True, total=parser.max_sessions)
 
@@ -192,6 +194,17 @@ if ntf:
   _in -> ntf
   _in = ntf
 
+_in -> qerLookup::ExactMatch(fields=[{'attr_name':'qer_id', 'num_bytes':4}, \
+                                     {'attr_name':'fseid', 'num_bytes':8}], \
+                             values=[{'attr_name':'qfi', 'num_bytes':1}, \
+                                     {'attr_name':'ulStatus', 'num_bytes':1},\
+                                     {'attr_name':'dlStatus', 'num_bytes':1},\
+                                     {'attr_name':'ulMbr', 'num_bytes':4},\
+                                     {'attr_name':'dlMbr', 'num_bytes':4},\
+                                     {'attr_name':'ulGbr', 'num_bytes':4},\
+                                     {'attr_name':'dlGbr', 'num_bytes':4}])
+
+_in = qerLookup
 _in -> farLookup::ExactMatch(fields=[{'attr_name':'far_id', 'num_bytes':4}, \
                                      {'attr_name':'fseid', 'num_bytes':8}], \
                              values=[{'attr_name':'action', 'num_bytes':1}, \
@@ -224,6 +237,7 @@ executeFAR:farNotifyCPAction -> pfcpDetails::GenericEncap(fields=[ {'size': 8, '
 pktParse:0 -> badPkts::Sink()
 pdrLookup:pdrFailGate -> pdrLookupFail::Sink()
 farLookup:farFailGate -> farLookupFail::Sink()
+qerLookup:qerFailGate -> qerLookupFail::Sink()
 executeFAR:farDropAction -> farDrop::Sink()
 executeFAR:farBufferAction -> farBuffer::Sink()
 gtpuEncap:0 -> gtpuEncapFail::Sink()
@@ -231,6 +245,7 @@ gtpuEncap:0 -> gtpuEncapFail::Sink()
 # Set default gates for relevant modules
 pdrLookup.set_default_gate(gate=pdrFailGate)
 farLookup.set_default_gate(gate=farFailGate)
+qerLookup.set_default_gate(gate=qerFailGate)
 
 
 # ====================================================

--- a/core/modules/gtpu_encap.cc
+++ b/core/modules/gtpu_encap.cc
@@ -92,6 +92,10 @@ void GtpuEncap::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
     bess::metadata::mt_offset_t off = attr_offset(pdu_type_attr);
     at_pdu_type = get_attr_with_offset<uint8_t>(off, p);
 
+    uint8_t at_qfi;
+    off = attr_offset(qfi_attr);
+    at_qfi = get_attr_with_offset<uint8_t>(off, p);
+
     uint32_t at_tout_sip;
     off = attr_offset(tout_sip_attr);
     at_tout_sip = get_attr_with_offset<uint32_t>(off, p);
@@ -110,6 +114,7 @@ void GtpuEncap::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
 
     /* checking values now */
     DLOG(INFO) << "pdu type: " << static_cast<uint16_t>(at_pdu_type)
+               << ", tunnel qfi: " << at_qfi
                << ", tunnel out sip: " << at_tout_sip
                << ", tunnel out dip: " << at_tout_dip
                << ", tunnel out teid: " << at_tout_teid
@@ -146,6 +151,7 @@ void GtpuEncap::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
     /* setting gtp psc extension header*/
     if (add_psc) {
       gtph->ex = 1;
+      psch->qfi = at_qfi;
       psch->pdu_type = at_pdu_type;
     }
 
@@ -195,6 +201,9 @@ CommandResponse GtpuEncap::Init(const bess::pb::GtpuEncapArg &arg) {
   tout_uport = AddMetadataAttr("tunnel_out_udp_port", sizeof(uint16_t),
                                AccessMode::kRead);
   DLOG(INFO) << "tout_uport: " << tout_uport << std::endl;
+  qfi_attr =
+      AddMetadataAttr("qfi", sizeof(uint8_t), AccessMode::kRead);
+  DLOG(INFO) << "qfi_attr: " << qfi_attr << std::endl;
 
   return CommandSuccess();
 }

--- a/core/modules/gtpu_encap.h
+++ b/core/modules/gtpu_encap.h
@@ -36,6 +36,7 @@ class GtpuEncap final : public Module {
   bool add_psc;
   int encap_size;
   int pdu_type_attr = -1;
+  int qfi_attr = -1;
   int tout_sip_attr = -1;
   int tout_dip_attr = -1;
   int tout_teid = -1;

--- a/pfcpiface/bess.go
+++ b/pfcpiface/bess.go
@@ -60,10 +60,10 @@ func (b *bess) sendEndMarkers(endMarkerList *[][]byte) error {
 	return nil
 }
 
-func (b *bess) sendMsgToUPF(method string, pdrs []pdr, fars []far) uint8 {
+func (b *bess) sendMsgToUPF(method string, pdrs []pdr, fars []far, qers []qer) uint8 {
 	// create context
 	var cause uint8 = ie.CauseRequestAccepted
-	calls := len(pdrs) + len(fars)
+	calls := len(pdrs) + len(fars) + len(qers)
 	if calls == 0 {
 		return cause
 	}
@@ -94,6 +94,17 @@ func (b *bess) sendMsgToUPF(method string, pdrs []pdr, fars []far) uint8 {
 			b.addFAR(ctx, done, far)
 		case "del":
 			b.delFAR(ctx, done, far)
+		}
+	}
+	for _, qer := range qers {
+		// qer.printQER()
+		switch method {
+		case "add":
+			fallthrough
+		case "mod":
+			b.addQER(ctx, done, qer)
+		case "del":
+			b.delQER(ctx, done, qer)
 		}
 	}
 	rc := b.GRPCJoin(calls, Timeout, done)
@@ -372,6 +383,7 @@ func (b *bess) sim(u *upf, method string) {
 			fseID:     uint64(n3TEID + i),
 			ctrID:     i,
 			farID:     n3,
+			qerID:     n3,
 			needDecap: 0,
 		}
 
@@ -389,6 +401,7 @@ func (b *bess) sim(u *upf, method string) {
 			fseID:     uint64(n3TEID + i),
 			ctrID:     i,
 			farID:     n3,
+			qerID:     n3,
 			needDecap: 1,
 		}
 
@@ -409,6 +422,7 @@ func (b *bess) sim(u *upf, method string) {
 			fseID:     uint64(n3TEID + i),
 			ctrID:     i,
 			farID:     n6,
+			qerID:     n6,
 			needDecap: 1,
 		}
 
@@ -428,6 +442,7 @@ func (b *bess) sim(u *upf, method string) {
 			fseID:     uint64(n3TEID + i),
 			ctrID:     i,
 			farID:     n9,
+			qerID:     n9,
 			needDecap: 1,
 		}
 
@@ -471,12 +486,51 @@ func (b *bess) sim(u *upf, method string) {
 
 		fars := []far{farDown, farN6Up, farN9Up}
 
+		// create/delete uplink qer
+		qerDown := qer{
+			qerID: n3,
+			fseID: uint64(n3TEID + i),
+
+			qfi:      9,
+			ulStatus: 0,
+			dlStatus: 0,
+			ulMbr:    50000,
+			dlMbr:    50000,
+			ulGbr:    50000,
+			dlGbr:    50000,
+		}
+
+		qerN6Up := qer{
+			qerID:    n6,
+			fseID:    uint64(n3TEID + i),
+			qfi:      8,
+			ulStatus: 0,
+			dlStatus: 0,
+			ulMbr:    50000,
+			dlMbr:    50000,
+			ulGbr:    50000,
+			dlGbr:    50000,
+		}
+
+		qerN9Up := qer{
+			qerID:    n9,
+			fseID:    uint64(n3TEID + i),
+			qfi:      7,
+			ulStatus: 0,
+			dlStatus: 0,
+			ulMbr:    50000,
+			dlMbr:    50000,
+			ulGbr:    50000,
+			dlGbr:    50000,
+		}
+
+		qers := []qer{qerDown, qerN6Up, qerN9Up}
 		switch method {
 		case "create":
-			b.sendMsgToUPF("add", pdrs, fars)
+			b.sendMsgToUPF("add", pdrs, fars, qers)
 
 		case "delete":
-			b.sendMsgToUPF("del", pdrs, fars)
+			b.sendMsgToUPF("del", pdrs, fars, qers)
 
 		default:
 			log.Fatalln("Unsupported method", method)
@@ -533,6 +587,7 @@ func (b *bess) addPDR(ctx context.Context, done chan<- bool, p pdr) {
 				intEnc(uint64(p.pdrID)), /* pdr-id */
 				intEnc(uint64(p.fseID)), /* fseid */
 				intEnc(uint64(p.ctrID)), /* ctr_id */
+				intEnc(uint64(p.qerID)), /* qer_id */
 				intEnc(uint64(p.farID)), /* far_id */
 			},
 		}
@@ -581,6 +636,73 @@ func (b *bess) delPDR(ctx context.Context, done chan<- bool, p pdr) {
 		}
 
 		b.processPDR(ctx, any, "delete")
+		done <- true
+	}()
+}
+
+func (b *bess) processQER(ctx context.Context, any *anypb.Any, method string) {
+	if method != "add" && method != "delete" && method != "clear" {
+		log.Println("Invalid method name: ", method)
+		return
+	}
+
+	_, err := b.client.ModuleCommand(ctx, &pb.CommandRequest{
+		Name: "qerLookup",
+		Cmd:  method,
+		Arg:  any,
+	})
+	if err != nil {
+		log.Println("qerLookup method failed!:", err)
+	}
+}
+
+func (b *bess) addQER(ctx context.Context, done chan<- bool, qer qer) {
+	go func() {
+		var any *anypb.Any
+		var err error
+		q := &pb.ExactMatchCommandAddArg{
+			Gate: uint64(0),
+			Fields: []*pb.FieldData{
+				intEnc(uint64(qer.qerID)), /* far_id */
+				intEnc(uint64(qer.fseID)), /* fseid */
+			},
+			Values: []*pb.FieldData{
+				intEnc(uint64(qer.qfi)),      /* action */
+				intEnc(uint64(qer.ulStatus)), /* QFI */
+				intEnc(uint64(qer.dlStatus)), /* tunnel_out_type */
+				intEnc(uint64(qer.ulMbr)),    /* access-ip */
+				intEnc(uint64(qer.dlMbr)),    /* enb ip */
+				intEnc(uint64(qer.ulGbr)),    /* enb teid */
+				intEnc(uint64(qer.dlGbr)),    /* udp gtpu port */
+			},
+		}
+		any, err = anypb.New(q)
+		if err != nil {
+			log.Println("Error marshalling the rule", q, err)
+			return
+		}
+		b.processQER(ctx, any, "add")
+		done <- true
+	}()
+}
+
+func (b *bess) delQER(ctx context.Context, done chan<- bool, qer qer) {
+	go func() {
+		var any *anypb.Any
+		var err error
+
+		q := &pb.ExactMatchCommandDeleteArg{
+			Fields: []*pb.FieldData{
+				intEnc(uint64(qer.qerID)), /* qer_id */
+				intEnc(uint64(qer.fseID)), /* fseid */
+			},
+		}
+		any, err = anypb.New(q)
+		if err != nil {
+			log.Println("Error marshalling the rule", q, err)
+			return
+		}
+		b.processQER(ctx, any, "delete")
 		done <- true
 	}()
 }

--- a/pfcpiface/fastpath.go
+++ b/pfcpiface/fastpath.go
@@ -17,10 +17,10 @@ type fastPath interface {
 	setInfo(udpConn *net.UDPConn, udpAddr net.Addr, pconn *PFCPConn)
 	/* simulator mode setup */
 	sim(u *upf, method string)
-	/* write pdr/far/qer to fastpath */
-	sendMsgToUPF(method string, pdrs []pdr, fars []far) uint8
 	/* write endMarker to fastpath */
 	sendEndMarkers(endMarkerList *[][]byte) error
+	/* write pdr/far/qer to fastpath */
+	sendMsgToUPF(method string, pdrs []pdr, fars []far, qers []qer) uint8
 	/* delete all pdrs/fars/qers/ installed in fastpath tabled */
 	sendDeleteAllSessionsMsgtoUPF()
 	/* check of communication channel to fastpath is setup */

--- a/pfcpiface/p4rt.go
+++ b/pfcpiface/p4rt.go
@@ -244,7 +244,7 @@ func (p *p4rtc) sendDeleteAllSessionsMsgtoUPF() {
 	log.Println("Loop through sessions and delete all entries p4")
 	if (p.pfcpConn != nil) && (p.pfcpConn.mgr != nil) {
 		for seidKey, value := range p.pfcpConn.mgr.sessions {
-			p.sendMsgToUPF("del", value.pdrs, value.fars)
+			p.sendMsgToUPF("del", value.pdrs, value.fars, nil)
 			p.pfcpConn.mgr.RemoveSession(seidKey)
 		}
 	}
@@ -307,7 +307,8 @@ func (p *p4rtc) sendEndMarkers(endMarkerList *[][]byte) error {
 	return nil
 }
 
-func (p *p4rtc) sendMsgToUPF(method string, pdrs []pdr, fars []far) uint8 {
+func (p *p4rtc) sendMsgToUPF(method string, pdrs []pdr,
+	fars []far, qers []qer) uint8 {
 	log.Println("sendMsgToUPF p4")
 	var funcType uint8
 	var err error

--- a/pfcpiface/parse-pdr.go
+++ b/pfcpiface/parse-pdr.go
@@ -35,6 +35,7 @@ type pdr struct {
 	fseidIP     uint32
 	ctrID       uint32
 	farID       uint32
+	qerID       uint32
 	needDecap   uint8
 	allocIPFlag bool
 }
@@ -69,6 +70,7 @@ func (p *pdr) printPDR() {
 	log.Println("fseidIP", p.fseidIP)
 	log.Println("ctrID:", p.ctrID)
 	log.Println("farID:", p.farID)
+	log.Println("qerID:", p.qerID)
 	log.Println("needDecap:", p.needDecap)
 	log.Println("allocIPFlag:", p.allocIPFlag)
 	log.Println("--------------------------------------------")
@@ -97,7 +99,6 @@ func (p *pdr) parsePDI(pdiIEs []*ie.IE, appPFDs map[string]appPFD, upf *upf) err
 				p.allocIPFlag = true
 				log.Println("ueipv4 : ", ueIP4.String())
 			} else {
-				log.Println("CP has allocated UE IP.")
 				ueIP4 = ueIPaddr.IPv4Address
 			}
 		case ie.SourceInterface:
@@ -272,11 +273,17 @@ func (p *pdr) parsePDR(ie1 *ie.IE, seid uint64, appPFDs map[string]appPFD, upf *
 		return nil
 	}
 
+	qerID, err := ie1.QERID()
+	if err != nil {
+		log.Println("Could not read QER ID!")
+	}
+
 	p.precedence = precedence
 	p.pdrID = uint32(pdrID)
 	p.fseID = (seid) // fseID currently being truncated to uint32 <--- FIXIT/TODO/XXX
 	p.ctrID = 0      // ctrID currently not being set <--- FIXIT/TODO/XXX
 	p.farID = farID  // farID currently not being set <--- FIXIT/TODO/XXX
+	p.qerID = qerID
 	p.needDecap = outerHeaderRemoval
 
 	return nil

--- a/pfcpiface/parse-qer.go
+++ b/pfcpiface/parse-qer.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright(c) 2020 Intel Corporation
+
+package main
+
+import (
+	"log"
+
+	"github.com/wmnsk/go-pfcp/ie"
+)
+
+type qer struct {
+	qerID    uint32
+	qfi      uint8
+	ulStatus uint8
+	dlStatus uint8
+	ulMbr    uint64
+	dlMbr    uint64
+	ulGbr    uint64
+	dlGbr    uint64
+	fseID    uint64
+	fseidIP  uint32
+}
+
+func (q *qer) printQER() {
+	log.Println("------------------ QER ---------------------")
+	log.Println("QER ID:", q.qerID)
+	log.Println("fseID:", q.fseID)
+	log.Println("QFI:", q.qfi)
+	log.Println("fseIDIP:", int2ip(q.fseidIP))
+	log.Println("Uplink Status:", q.ulStatus)
+	log.Println("Downling Status:", q.dlStatus)
+	log.Println("Uplink MBR:", q.ulMbr)
+	log.Println("Downlink MBR:", q.dlMbr)
+	log.Println("Uplink GBR:", q.ulGbr)
+	log.Println("Downlink GBR:", q.dlGbr)
+	log.Println("--------------------------------------------")
+}
+func (q *qer) parseQER(ie1 *ie.IE, seid uint64, upf *upf) error {
+
+	qerID, err := ie1.QERID()
+	if err != nil {
+		log.Println("Could not read QER ID!")
+		return nil
+	}
+
+	qfi, err := ie1.QFI()
+	if err != nil {
+		log.Println("Could not read QFI!")
+	}
+
+	gsUL, err := ie1.GateStatusUL()
+	if err != nil {
+		log.Println("Could not read Gate status uplink!")
+	}
+
+	gsDL, err := ie1.GateStatusDL()
+	if err != nil {
+		log.Println("Could not read Gate status downlink!")
+	}
+
+	mbrUL, err := ie1.MBRUL()
+	if err != nil {
+		log.Println("Could not read MBRUL!")
+	}
+
+	mbrDL, err := ie1.MBRDL()
+	if err != nil {
+		log.Println("Could not read MBRDL!")
+	}
+
+	gbrUL, err := ie1.GBRUL()
+	if err != nil {
+		log.Println("Could not read GBRUL!")
+	}
+
+	gbrDL, err := ie1.GBRDL()
+	if err != nil {
+		log.Println("Could not read GBRDL!")
+	}
+
+	q.qerID = uint32(qerID)
+	q.qfi = uint8(qfi)
+	q.ulStatus = uint8(gsUL)
+	q.dlStatus = uint8(gsDL)
+	q.ulMbr = uint64(mbrUL)
+	q.dlMbr = uint64(mbrDL)
+	q.ulGbr = uint64(gbrUL)
+	q.dlGbr = uint64(gbrDL)
+	q.fseID = (seid) // fseID currently being truncated to uint32 <--- FIXIT/TODO/XXX
+
+	return nil
+}

--- a/pfcpiface/pfcpsim.go
+++ b/pfcpiface/pfcpsim.go
@@ -117,6 +117,7 @@ func createPFCP(conn *net.UDPConn, raddr *net.UDPAddr) uint64 {
 				),
 				ie.NewOuterHeaderRemoval(0, 0),
 				ie.NewFARID(1),
+				ie.NewQERID(1),
 			),
 			// Uplink N6
 			ie.NewCreatePDR(
@@ -131,6 +132,7 @@ func createPFCP(conn *net.UDPConn, raddr *net.UDPAddr) uint64 {
 				),
 				ie.NewOuterHeaderRemoval(0, 0),
 				ie.NewFARID(2),
+				ie.NewQERID(2),
 			),
 			// Downlink N9
 			ie.NewCreatePDR(
@@ -142,6 +144,7 @@ func createPFCP(conn *net.UDPConn, raddr *net.UDPAddr) uint64 {
 				),
 				ie.NewOuterHeaderRemoval(0, 0),
 				ie.NewFARID(3),
+				ie.NewQERID(3),
 			),
 			// Downlink N6
 			ie.NewCreatePDR(
@@ -180,6 +183,30 @@ func createPFCP(conn *net.UDPConn, raddr *net.UDPAddr) uint64 {
 				//	ie.NewDestinationInterface(ie.DstInterfaceAccess),
 				//	ie.NewOuterHeaderCreation(0x100, 0x00000001, "11.1.1.129", "", 0, 0, 0),
 				//),
+			),
+			// Uplink N9
+			ie.NewCreateQER(
+				ie.NewQERID(1),
+				ie.NewQFI(0x09),
+				ie.NewGateStatus(0, 0),
+				ie.NewMBR(50000, 50000),
+				ie.NewGBR(30000, 30000),
+			),
+			// Uplink N6
+			ie.NewCreateQER(
+				ie.NewQERID(2),
+				ie.NewQFI(0x08),
+				ie.NewGateStatus(0, 0),
+				ie.NewMBR(50000, 50000),
+				ie.NewGBR(30000, 30000),
+			),
+			// Downlink
+			ie.NewCreateQER(
+				ie.NewQERID(3),
+				ie.NewQFI(0x07),
+				ie.NewGateStatus(0, 0),
+				ie.NewMBR(50000, 50000),
+				ie.NewGBR(30000, 30000),
 			),
 		).Marshal()
 		if err != nil {
@@ -233,6 +260,7 @@ func modifyPFCP(conn *net.UDPConn, raddr *net.UDPAddr, seid uint64) {
 				),
 				ie.NewOuterHeaderRemoval(0, 0),
 				ie.NewFARID(3),
+				ie.NewQERID(3),
 			),
 			// Downlink N6
 			ie.NewUpdatePDR(
@@ -244,6 +272,7 @@ func modifyPFCP(conn *net.UDPConn, raddr *net.UDPAddr, seid uint64) {
 					ie.NewSDFFilter("permit out ip from any to assigned", "", "", "", 1),
 				),
 				ie.NewFARID(3),
+				ie.NewQERID(3),
 			),
 			// Downlink
 			ie.NewUpdateFAR(
@@ -253,6 +282,13 @@ func modifyPFCP(conn *net.UDPConn, raddr *net.UDPAddr, seid uint64) {
 					ie.NewDestinationInterface(ie.DstInterfaceAccess),
 					ie.NewOuterHeaderCreation(0x100, 0x00000001, "11.1.1.129", "", 0, 0, 0),
 				),
+			),
+			ie.NewUpdateQER(
+				ie.NewQERID(3),
+				ie.NewQFI(0x06),
+				ie.NewGateStatus(0, 0),
+				ie.NewMBR(50000, 50000),
+				ie.NewGBR(30000, 30000),
 			),
 		).Marshal()
 		if err != nil {

--- a/pfcpiface/session-qer.go
+++ b/pfcpiface/session-qer.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright(c) 2020 Intel Corporation
+
+package main
+
+import (
+	"errors"
+)
+
+// CreateQER appends qer to existing list of QERs in the session
+func (s *PFCPSession) CreateQER(q qer) {
+	s.qers = append(s.qers, q)
+}
+
+// UpdateQER updates existing qer in the session
+func (s *PFCPSession) UpdateQER(q qer) error {
+	for idx, v := range s.qers {
+		if v.qerID == q.qerID {
+			s.qers[idx] = q
+			return nil
+		}
+	}
+	return errors.New("QER not found")
+}
+
+// RemoveQER removes qer from existing list of QERs in the session
+func (s *PFCPSession) RemoveQER(id uint32) (*qer, error) {
+	for idx, v := range s.qers {
+		if v.qerID == id {
+			s.qers = append(s.qers[:idx], s.qers[idx+1:]...)
+			return &v, nil
+		}
+	}
+	return nil, errors.New("QER not found")
+}

--- a/pfcpiface/sessions.go
+++ b/pfcpiface/sessions.go
@@ -51,6 +51,7 @@ type PFCPSession struct {
 	notificationFlag notifyFlag
 	pdrs             []pdr
 	fars             []far
+	qers             []qer
 }
 
 // NewPFCPSession allocates an session with ID
@@ -67,6 +68,7 @@ func (mgr *PFCPSessionMgr) NewPFCPSession(rseid uint64) uint64 {
 			remoteSEID: rseid,
 			pdrs:       make([]pdr, 0, MaxItems),
 			fars:       make([]far, 0, MaxItems),
+			qers:       make([]qer, 0, MaxItems),
 		}
 		mgr.sessions[lseid] = &s
 		globalPfcpStats.sessions.WithLabelValues(mgr.nodeID).Set(float64(len(mgr.sessions)))

--- a/pfcpiface/upf.go
+++ b/pfcpiface/upf.go
@@ -54,8 +54,8 @@ const (
 	farNotify   = 0x4
 )
 
-func (u *upf) sendMsgToUPF(method string, pdrs []pdr, fars []far) uint8 {
-	return u.intf.sendMsgToUPF(method, pdrs, fars)
+func (u *upf) sendMsgToUPF(method string, pdrs []pdr, fars []far, qers []qer) uint8 {
+	return u.intf.sendMsgToUPF(method, pdrs, fars, qers)
 }
 
 func (u *upf) sendEndMarkers(endMarkerList *[][]byte) error {


### PR DESCRIPTION
Store, update and delete QER information received in Pfcp message. 
Pass on the QER information to BESS module. 
Use the QFI received in QER in the GTPU extension header when gtppsc feature is enabled.