### PR TITLE
Qos metering support

### DIFF
--- a/bessctl/module_tests/metering.bess
+++ b/bessctl/module_tests/metering.bess
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright(c) 2021 Intel Corporation
+
+# Update assignments to hit different QoS entries
+iface, qer, fseid = 1, 2, 4
+ip_pkt_size = 46
+sleep_seconds_before_delete = 30
+
+import struct
+def convert(format, val, bigendian=True):
+    end = '>' if [bigendian] else '<'
+    return struct.pack(end + format, val, )
+
+
+Meta::SetMetadata(attrs=[{'name': 'src_iface', 'size': 1, 'value_int': iface},
+                         {'name': 'qer_id', 'size':4, 'value_int': qer},
+                         {'name': 'fseid', 'size':8, 'value_int': fseid}])
+
+Metering::Qos(fields=[{'attr_name':'src_iface', 'num_bytes':1},
+                      {'attr_name':'qer_id', 'num_bytes':4},
+                      {'attr_name':'fseid', 'num_bytes':8}],
+              values=[{'attr_name':'qfi', 'num_bytes':1}])
+
+M::Merge()
+S::Split(size=1, attribute='qfi')
+
+# Reserved gates, reject rule adds with gate=1/2/3
+m_meter  = 0 # Placeholder gate not connected. Will meter if lookup result returns this gate
+m_green  = 1 # For green traffic
+m_yellow = 2 # For yellow traffic
+m_red    = 3 # For red traffic
+
+# Rules with gate number above 3 are directly sent out w/o metering
+m_fail   = 4 # Default gate for lookup failure
+m_drop   = 5 # Explicitly asked to drop
+m_unmeter= 6 # Unmetered
+
+Metering:m_green -> M
+Metering:m_yellow -> M
+Metering:m_red -> red::Sink()
+Metering:m_drop -> drop::Sink()
+Metering:m_unmeter -> S
+
+Metering:m_fail -> fail::Sink()
+Metering.set_default_gate(gate=m_fail)
+
+# Pipeline
+Source() -> Meta -> Metering
+M -> S
+
+S:0 -> bad::Sink() # If traffic is going to this gate, meta update in QoS is not working
+S:1 -> gbr1::Sink()
+S:2 -> gbr5::Sink()
+S:3 -> gmbr6::Sink()
+S:4 -> mbr6::Sink()
+S:5 -> unmeter::Sink()
+
+# Resume workers to test concurrent read-write
+bess.resume_all()
+
+MPPS = pow(10,6) * ip_pkt_size
+
+# Add QoS entries
+# GBR only
+Metering.add(fields=[{'value_int': 1},
+                     {'value_bin': convert('L', 2)},
+                     {'value_bin': convert('Q', 4)}],
+             values=[{'value_int': 1}], # S:1
+             gate=m_meter, cir=1 * MPPS , pir=1 * MPPS, cbs=2048, pbs=2048)
+
+Metering.add(fields=[{'value_int': 1},
+                     {'value_bin': convert('L', 3)},
+                     {'value_bin': convert('Q', 6)}],
+             values=[{'value_int': 2}], # S:2
+             gate=m_meter, cir=5 * MPPS, pir=5 * MPPS, cbs=2048, pbs=2048)
+
+# GBR/MBR
+Metering.add(fields=[{'value_int': 1},
+                     {'value_bin': convert('L', 4)},
+                     {'value_bin': convert('Q', 8)}],
+             values=[{'value_int': 3}], # S:3
+             gate=m_meter, cir=3 * MPPS, pir=6 * MPPS, cbs=2048, pbs=2048)
+
+# MBR only
+Metering.add(fields=[{'value_int': 1},
+                     {'value_bin': convert('L', 5)},
+                     {'value_bin': convert('Q', 10)}],
+             values=[{'value_int': 4}], # S:4
+             gate=m_meter, cir=1, pir=6 * MPPS, cbs=2048, pbs=2048)
+
+# Unmeter
+Metering.add(fields=[{'value_int': 1},
+                     {'value_bin': convert('L', 6)},
+                     {'value_bin': convert('Q', 12)}],
+             values=[{'value_int': 5}], # S:5
+             gate=m_unmeter)
+
+# Gate closed
+Metering.add(fields=[{'value_int': 1},
+                     {'value_bin': convert('L', 2)},
+                     {'value_bin': convert('Q', 3)}],
+             values=[{'value_int': 5}],
+             gate=m_drop)
+
+# Delete QoS entries after sleep
+import time
+time.sleep(sleep_seconds_before_delete)
+
+# GBR only
+Metering.delete(fields=[{'value_int': 1},
+                     {'value_bin': convert('L', 2)},
+                     {'value_bin': convert('Q', 4)}])
+
+Metering.delete(fields=[{'value_int': 1},
+                     {'value_bin': convert('L', 3)},
+                     {'value_bin': convert('Q', 6)}])
+
+# GBR/MBR
+Metering.delete(fields=[{'value_int': 1},
+                     {'value_bin': convert('L', 4)},
+                     {'value_bin': convert('Q', 8)}])
+
+# MBR only
+Metering.delete(fields=[{'value_int': 1},
+                     {'value_bin': convert('L', 5)},
+                     {'value_bin': convert('Q', 10)}])
+
+# Unmeter
+Metering.delete(fields=[{'value_int': 1},
+                     {'value_bin': convert('L', 6)},
+                     {'value_bin': convert('Q', 12)}])
+
+# Gate closed
+Metering.delete(fields=[{'value_int': 1},
+                     {'value_bin': convert('L', 2)},
+                     {'value_bin': convert('Q', 3)}])

--- a/conf/up4.bess
+++ b/conf/up4.bess
@@ -27,7 +27,12 @@ farBufferAction = 3
 farNotifyCPAction = 4
 pdrFailGate = 2
 farFailGate = 2
-qerFailGate = 1
+qerGreenGate = 1
+qerYellowGate = 2
+qerRedGate = 3
+qerFailGate = 4
+qerStatusDropGate = 5
+qerUnmeteredGate = 6
 interfaces = ["access", "core"]
 parser = Parser('conf/upf.json')
 parser.parse(interfaces)
@@ -194,18 +199,12 @@ if ntf:
   _in -> ntf
   _in = ntf
 
-_in -> qerLookup::ExactMatch(fields=[{'attr_name':'qer_id', 'num_bytes':4}, \
-                                     {'attr_name':'fseid', 'num_bytes':8}], \
-                             values=[{'attr_name':'qfi', 'num_bytes':1}, \
-                                     {'attr_name':'ulStatus', 'num_bytes':1},\
-                                     {'attr_name':'dlStatus', 'num_bytes':1},\
-                                     {'attr_name':'ulMbr', 'num_bytes':4},\
-                                     {'attr_name':'dlMbr', 'num_bytes':4},\
-                                     {'attr_name':'ulGbr', 'num_bytes':4},\
-                                     {'attr_name':'dlGbr', 'num_bytes':4}])
+_in -> qerLookup::Qos(fields=[ {'attr_name':'src_iface', 'num_bytes':1}, \
+                               {'attr_name':'qer_id', 'num_bytes':4}, \
+                               {'attr_name':'fseid', 'num_bytes':8}], \
+                             values=[{'attr_name':'qfi', 'num_bytes':1}])
 
-_in = qerLookup
-_in -> farLookup::ExactMatch(fields=[{'attr_name':'far_id', 'num_bytes':4}, \
+farLookup::ExactMatch(fields=[{'attr_name':'far_id', 'num_bytes':4}, \
                                      {'attr_name':'fseid', 'num_bytes':8}], \
                              values=[{'attr_name':'action', 'num_bytes':1}, \
                                      {'attr_name':'tunnel_out_type', 'num_bytes':1}, \
@@ -235,6 +234,11 @@ executeFAR:farNotifyCPAction -> pfcpDetails::GenericEncap(fields=[ {'size': 8, '
                              -> farNotifyCP::PortOut(port='notifyCP')
 # Drop unknown packets
 pktParse:0 -> badPkts::Sink()
+qerLookup:qerGreenGate -> farLookup
+qerLookup:qerYellowGate -> farLookup
+qerLookup:qerRedGate -> qerMeterRed::Sink()
+qerLookup:qerStatusDropGate -> qerStatusDrop::Sink()
+qerLookup:qerUnmeteredGate -> farLookup
 pdrLookup:pdrFailGate -> pdrLookupFail::Sink()
 farLookup:farFailGate -> farLookupFail::Sink()
 qerLookup:qerFailGate -> qerLookupFail::Sink()

--- a/conf/upf.json
+++ b/conf/upf.json
@@ -73,6 +73,22 @@
     "" : "notify_sockaddr: /tmp/notifycp",
     "" : "endmarker_sockaddr: /tmp/pfcpport",
 
+    "qci_qos_config": [
+        {
+            "qci": 9,
+            "cbs": 2048,
+            "ebs": 2048,
+            "pbs": 2048,
+            "priority": 6
+        },
+        {
+            "qci": 8,
+            "cbs": 2048,
+            "ebs": 2048,
+            "pbs": 2048,
+            "priority": 5
+        }
+    ],
     "": "Control plane controller settings",
     "cpiface": {
         "enable_ue_ip_alloc": false,

--- a/core/modules/qos.cc
+++ b/core/modules/qos.cc
@@ -1,0 +1,450 @@
+// Copyright (c) 2014-2016, The Regents of the University of California.
+// Copyright (c) 2016-2017, Nefeli Networks, Inc.
+// Copyright (c) 2021 Intel Corporation
+// All rights reserved
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// * Neither the names of the copyright holders nor the names of their
+// contributors may be used to endorse or promote products derived from this
+// software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include "qos.h"
+#include "utils/endian.h"
+#include "utils/ether.h"
+#include "utils/format.h"
+
+#include <rte_cycles.h>
+#include <string>
+#include <vector>
+
+using bess::utils::Ethernet;
+
+typedef enum { FIELD_TYPE = 0, VALUE_TYPE } Type;
+using bess::metadata::Attribute;
+#define metering_test 0
+static inline int is_valid_gate(gate_idx_t gate) {
+  return (gate == METER_GATE || (gate > METER_RED_GATE && gate < MAX_GATES) ||
+          gate == DROP_GATE);
+}
+
+const Commands Qos::cmds = {
+    {"add", "QosCommandAddArg", MODULE_CMD_FUNC(&Qos::CommandAdd),
+     Command::THREAD_SAFE},
+    {"delete", "QosCommandDeleteArg", MODULE_CMD_FUNC(&Qos::CommandDelete),
+     Command::THREAD_SAFE},
+    {"clear", "EmptyArg", MODULE_CMD_FUNC(&Qos::CommandClear),
+     Command::THREAD_SAFE},
+    {"set_default_gate", "QosCommandSetDefaultGateArg",
+     MODULE_CMD_FUNC(&Qos::CommandSetDefaultGate), Command::THREAD_SAFE}};
+
+CommandResponse Qos::AddFieldOne(const bess::pb::Field &field,
+                                 struct MeteringField *f, uint8_t type) {
+  f->size = field.num_bytes();
+
+  if (f->size < 1 || f->size > MAX_FIELD_SIZE) {
+    return CommandFailure(EINVAL, "'size' must be 1-%d", MAX_FIELD_SIZE);
+  }
+
+  if (field.position_case() == bess::pb::Field::kOffset) {
+    f->attr_id = -1;
+    f->offset = field.offset();
+    if (f->offset < 0 || f->offset > 1024) {
+      return CommandFailure(EINVAL, "too small 'offset'");
+    }
+  } else if (field.position_case() == bess::pb::Field::kAttrName) {
+    const char *attr = field.attr_name().c_str();
+    f->attr_id =
+        (type == FieldType)
+            ? AddMetadataAttr(attr, f->size, Attribute::AccessMode::kRead)
+            : AddMetadataAttr(attr, f->size, Attribute::AccessMode::kWrite);
+
+    if (f->attr_id < 0) {
+      return CommandFailure(-f->attr_id, "add_metadata_attr() failed");
+    }
+  } else {
+    return CommandFailure(EINVAL, "specify 'offset' or 'attr'");
+  }
+
+  return CommandSuccess();
+}
+
+CommandResponse Qos::Init(const bess::pb::QosArg &arg) {
+  int size_acc = 0;
+  int value_acc = 0;
+
+  for (int i = 0; i < arg.fields_size(); i++) {
+    const auto &field = arg.fields(i);
+    CommandResponse err;
+    fields_.emplace_back();
+    struct MeteringField &f = fields_.back();
+    f.pos = size_acc;
+    err = AddFieldOne(field, &f, FieldType);
+    if (err.error().code() != 0) {
+      return err;
+    }
+
+    size_acc += f.size;
+  }
+  default_gate_ = DROP_GATE;
+  total_key_size_ = align_ceil(size_acc, sizeof(uint64_t));
+  for (int i = 0; i < arg.values_size(); i++) {
+    const auto &field = arg.values(i);
+    CommandResponse err;
+    values_.emplace_back();
+    struct MeteringField &f = values_.back();
+    f.pos = value_acc;
+    err = AddFieldOne(field, &f, ValueType);
+    if (err.error().code() != 0) {
+      return err;
+    }
+
+    value_acc += f.size;
+  }
+
+  total_value_size_ = align_ceil(value_acc, sizeof(uint64_t));
+
+  uint8_t *cs = (uint8_t *)&mask;
+  for (int i = 0; i < size_acc; i++) {
+    cs[i] = 0xff;
+  }
+
+  table_.Init(total_key_size_);
+  return CommandSuccess();
+}
+
+void Qos::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
+  gate_idx_t default_gate;
+  MeteringKey keys[bess::PacketBatch::kMaxBurst] __ymm_aligned;
+  bess::Packet *pkt = nullptr;
+  default_gate = ACCESS_ONCE(default_gate_);
+
+  int cnt = batch->cnt();
+  struct value *val[cnt];
+
+  for (const auto &field : fields_) {
+    int offset;
+    int pos = field.pos;
+    int attr_id = field.attr_id;
+
+    if (attr_id < 0) {
+      offset = field.offset;
+    } else {
+      offset = bess::Packet::mt_offset_to_databuf_offset(attr_offset(attr_id));
+    }
+
+    for (int j = 0; j < cnt; j++) {
+      pkt = batch->pkts()[j];
+      char *buf_addr = pkt->buffer<char *>();
+
+      /* for offset-based attrs we use relative offset */
+      if (attr_id < 0) {
+        buf_addr += pkt->data_off();
+      }
+
+      char *key = reinterpret_cast<char *>(keys[j].u64_arr) + pos;
+
+      *(reinterpret_cast<uint64_t *>(key)) =
+          *(reinterpret_cast<uint64_t *>(buf_addr + offset));
+
+      size_t len = reinterpret_cast<size_t>(total_key_size_ / sizeof(uint64_t));
+
+      for (size_t i = 0; i < len; i++) {
+        keys[j].u64_arr[i] = keys[j].u64_arr[i] & mask[i];
+      }
+    }
+  }
+
+  uint64_t hit_mask = table_.Find(keys, val, cnt);
+
+  for (int j = 0; j < cnt; j++) {
+    pkt = batch->pkts()[j];
+    if ((hit_mask & (1ULL << j)) == 0) {
+      EmitPacket(ctx, pkt, default_gate);
+      continue;
+    }
+
+    uint16_t ogate = val[j]->ogate;
+    DLOG(INFO) << "ogate : " << ogate << std::endl;
+
+    // meter if ogate is 0
+    if (ogate == METER_GATE) {
+      uint64_t time = rte_rdtsc();
+      uint32_t pkt_len = pkt->total_len() - sizeof(Ethernet);
+      uint8_t color = rte_meter_trtcm_color_blind_check(&val[j]->m, &val[j]->p,
+                                                        time, pkt_len);
+
+      DLOG(INFO) << "color : " << color << std::endl;
+      // update ogate to color specific gate
+      if (color == RTE_COLOR_GREEN) {
+        ogate = METER_GREEN_GATE;
+      } else if (color == RTE_COLOR_YELLOW) {
+        ogate = METER_YELLOW_GATE;
+      } else if (color == RTE_COLOR_RED) {
+        ogate = METER_RED_GATE;
+      }
+    }
+
+    // update values
+    size_t num_values_ = values_.size();
+    for (size_t i = 0; i < num_values_; i++) {
+      int value_size = values_[i].size;
+      int value_pos = values_[i].pos;
+      int value_off = values_[i].offset;
+      int value_attr_id = values_[i].attr_id;
+      uint8_t *data = pkt->head_data<uint8_t *>() + value_off;
+
+      if (value_attr_id < 0) { /* if it is offset-based */
+        memcpy(data, reinterpret_cast<uint8_t *>(&(val[j]->Data)) + value_pos,
+               value_size);
+      } else { /* if it is attribute-based */
+        typedef struct {
+          uint8_t bytes[bess::metadata::kMetadataAttrMaxSize];
+        } value_t;
+        uint8_t *buf = (uint8_t *)(&(val[j]->Data)) + value_pos;
+
+        DLOG(INFO) << "Setting value " << std::hex
+                   << *(reinterpret_cast<uint64_t *>(buf))
+                   << " for attr_id: " << value_attr_id
+                   << " of size: " << value_size
+                   << " at value_pos: " << value_pos << std::endl;
+
+        switch (value_size) {
+          case 1:
+            set_attr<uint8_t>(this, value_attr_id, pkt, *((uint8_t *)buf));
+            break;
+          case 2:
+            set_attr<uint16_t>(this, value_attr_id, pkt,
+                               *((uint16_t *)((uint8_t *)buf)));
+            break;
+          case 4:
+            set_attr<uint32_t>(this, value_attr_id, pkt,
+                               *((uint32_t *)((uint8_t *)buf)));
+            break;
+          case 8:
+            set_attr<uint64_t>(this, value_attr_id, pkt,
+                               *((uint64_t *)((uint8_t *)buf)));
+            break;
+          default: {
+            void *mt_ptr =
+                _ptr_attr_with_offset<value_t>(attr_offset(value_attr_id), pkt);
+            bess::utils::CopySmall(mt_ptr, buf, value_size);
+          } break;
+        }
+      }
+    }
+
+    EmitPacket(ctx, pkt, ogate);
+  }
+}
+
+template <typename T>
+CommandResponse Qos::ExtractKey(const T &arg, MeteringKey *key) {
+  if ((size_t)arg.fields_size() != fields_.size()) {
+    return CommandFailure(EINVAL, "must specify %zu masks", fields_.size());
+  }
+
+  memset(key, 0, sizeof(*key));
+
+  for (size_t i = 0; i < fields_.size(); i++) {
+    int field_size = fields_[i].size;
+    int field_pos = fields_[i].pos;
+
+    // uint64_t v = 0;
+    uint64_t k = 0;
+
+    bess::pb::FieldData fieldsdata = arg.fields(i);
+    if (fieldsdata.encoding_case() == bess::pb::FieldData::kValueInt) {
+      if (!bess::utils::uint64_to_bin(&k, fieldsdata.value_int(), field_size,
+                                      false)) {
+        return CommandFailure(EINVAL, "idx %zu: not a correct %d-byte mask", i,
+                              field_size);
+      }
+    } else if (fieldsdata.encoding_case() == bess::pb::FieldData::kValueBin) {
+      bess::utils::Copy(reinterpret_cast<uint8_t *>(&k),
+                        fieldsdata.value_bin().c_str(),
+                        fieldsdata.value_bin().size());
+    }
+
+    memcpy(reinterpret_cast<uint8_t *>(key) + field_pos, &k, field_size);
+  }
+  return CommandSuccess();
+}
+
+template <typename T>
+CommandResponse Qos::ExtractKeyMask(const T &arg, MeteringKey *key,
+                                    MeteringKey *val, MKey *l) {
+  if ((size_t)arg.fields_size() != fields_.size()) {
+    return CommandFailure(EINVAL, "must specify %zu masks", fields_.size());
+  }
+
+  memset(key, 0, sizeof(*key));
+  memset(val, 0, sizeof(*val));
+
+  for (size_t i = 0; i < fields_.size(); i++) {
+    int field_size = fields_[i].size;
+    int field_pos = fields_[i].pos;
+
+    uint64_t k = 0;
+
+    bess::pb::FieldData fieldsdata = arg.fields(i);
+    if (fieldsdata.encoding_case() == bess::pb::FieldData::kValueInt) {
+      if (!bess::utils::uint64_to_bin(&k, fieldsdata.value_int(), field_size,
+                                      false)) {
+        return CommandFailure(EINVAL, "idx %zu: not a correct %d-byte mask", i,
+                              field_size);
+      }
+    } else if (fieldsdata.encoding_case() == bess::pb::FieldData::kValueBin) {
+      bess::utils::Copy(reinterpret_cast<uint8_t *>(&k),
+                        fieldsdata.value_bin().c_str(),
+                        fieldsdata.value_bin().size());
+    }
+
+    memcpy(reinterpret_cast<uint8_t *>(key) + field_pos, &k, field_size);
+  }
+
+  for (size_t i = 0; i < fields_.size(); i++) {
+    int field_size = fields_[i].size;
+    int field_pos = fields_[i].pos;
+
+    uint64_t k = 0;
+
+    bess::pb::FieldData fieldsdata = arg.fields(i);
+    if (fieldsdata.encoding_case() == bess::pb::FieldData::kValueInt) {
+      if (!bess::utils::uint64_to_bin(&k, fieldsdata.value_int(), field_size,
+                                      false)) {
+        return CommandFailure(EINVAL, "idx %zu: not a correct %d-byte mask", i,
+                              field_size);
+      }
+    } else if (fieldsdata.encoding_case() == bess::pb::FieldData::kValueBin) {
+      bess::utils::Copy(reinterpret_cast<uint8_t *>(&k),
+                        fieldsdata.value_bin().c_str(),
+                        fieldsdata.value_bin().size());
+    }
+
+    memcpy(reinterpret_cast<uint8_t *>(l) + field_pos, &k, field_size);
+  }
+
+  for (size_t i = 0; i < values_.size(); i++) {
+    int val_size = values_[i].size;
+    int val_pos = values_[i].pos;
+
+    uint64_t v = 0;
+    bess::pb::FieldData valuedata = arg.values(i);
+    if (valuedata.encoding_case() == bess::pb::FieldData::kValueInt) {
+      if (!bess::utils::uint64_to_bin(&v, valuedata.value_int(), val_size,
+                                      false)) {
+        return CommandFailure(EINVAL, "idx %zu: not a correct %d-byte value", i,
+                              val_size);
+      }
+    } else if (valuedata.encoding_case() == bess::pb::FieldData::kValueBin) {
+      bess::utils::Copy(reinterpret_cast<uint8_t *>(&v),
+                        valuedata.value_bin().c_str(),
+                        valuedata.value_bin().size());
+    }
+
+    memcpy(reinterpret_cast<uint8_t *>(val) + val_pos, &v, val_size);
+  }
+  return CommandSuccess();
+}
+
+CommandResponse Qos::CommandAdd(const bess::pb::QosCommandAddArg &arg) {
+  gate_idx_t gate = arg.gate();
+
+  if (!is_valid_gate(gate)) {
+    return CommandFailure(EINVAL, "Invalid gate: %hu", gate);
+  }
+  MeteringKey key = {{0}};
+
+  MKey l;
+  struct value v;
+  v.ogate = gate;
+  CommandResponse err = ExtractKeyMask(arg, &key, &v.Data, &l);
+
+  if (err.error().code() != 0) {
+    return err;
+  }
+
+  if (gate == METER_GATE) {
+    v.cir = arg.cir();
+    v.pir = arg.pir();
+    v.cbs = arg.cbs();
+    v.pbs = arg.pbs();
+    v.ebs = arg.ebs();
+
+    DLOG(INFO) << "Adding entry"
+               << " cir: " << v.cir << " pir: " << v.pir << " cbs: " << v.cbs
+               << " pbs: " << v.pbs << " ebs: " << v.ebs << std::endl;
+
+    struct rte_meter_trtcm_params app_trtcm_params = {
+        .cir = v.cir, .pir = v.pir, .cbs = v.cbs, .pbs = v.pbs};
+
+    int ret = rte_meter_trtcm_profile_config(&v.p, &app_trtcm_params);
+    if (ret)
+      return CommandFailure(
+          ret, "Insert Failed - rte_meter_trtcm_profile_config failed");
+
+    ret = rte_meter_trtcm_config(&v.m, &v.p);
+    if (ret) {
+      return CommandFailure(ret,
+                            "Insert Failed - rte_meter_trtcm_config failed");
+    }
+  }
+
+  table_.Add(v, key);
+  return CommandSuccess();
+}
+
+CommandResponse Qos::CommandDelete(const bess::pb::QosCommandDeleteArg &arg) {
+  MeteringKey key;
+  CommandResponse err = ExtractKey(arg, &key);
+  table_.Delete(key);
+  return CommandSuccess();
+}
+
+CommandResponse Qos::CommandClear(__attribute__((unused))
+                                  const bess::pb::EmptyArg &) {
+  Qos::Clear();
+  return CommandSuccess();
+}
+
+void Qos::Clear() {
+  table_.Clear();
+}
+
+void Qos::DeInit() {
+  table_.DeInit();
+}
+
+CommandResponse Qos::CommandSetDefaultGate(
+    const bess::pb::QosCommandSetDefaultGateArg &arg) {
+  default_gate_ = arg.gate();
+  return CommandSuccess();
+}
+
+std::string Qos::GetDesc() const {
+  return bess::utils::Format("%zu fields, %zu rules", fields_.size(),
+                             table_.Count());
+}
+
+ADD_MODULE(Qos, "qos", "Multi-field classifier with a QOS")

--- a/core/modules/qos.h
+++ b/core/modules/qos.h
@@ -1,0 +1,123 @@
+// Copyright (c) 2014-2016, The Regents of the University of California.
+// Copyright (c) 2016-2017, Nefeli Networks, Inc.
+// Copyright (c) 2021 Intel Corporation
+// All rights reserved
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// * Neither the names of the copyright holders nor the names of their
+// contributors may be used to endorse or promote products derived from this
+// software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef BESS_MODULES_QOS_H_
+#define BESS_MODULES_QOS_H_
+
+#include "../module.h"
+
+#include <rte_config.h>
+#include <rte_hash_crc.h>
+
+#include "../pb/module_msg.pb.h"
+#include "../utils/metering.h"
+
+using bess::utils::Metering;
+using bess::utils::MeteringKey;
+
+#define MAX_FIELDS 8
+#define MAX_FIELD_SIZE 8
+static_assert(MAX_FIELD_SIZE <= sizeof(uint64_t),
+              "field cannot be larger than 8 bytes");
+
+#define HASH_KEY_SIZE (MAX_FIELDS * MAX_FIELD_SIZE)
+#define METER_GATE 0
+#define METER_GREEN_GATE 1
+#define METER_YELLOW_GATE 2
+#define METER_RED_GATE 3
+
+#if __BYTE_ORDER__ != __ORDER_LITTLE_ENDIAN__
+#error this code assumes little endian architecture (x86)
+#endif
+
+enum { FieldType = 0, ValueType };
+
+struct value {
+  gate_idx_t ogate;
+  uint64_t cir;
+  uint64_t pir;
+  uint64_t cbs;
+  uint64_t pbs;
+  uint64_t ebs;
+  struct rte_meter_trtcm_profile p;
+  struct rte_meter_trtcm m;
+  MeteringKey Data;
+} __attribute__((packed));
+
+struct MKey {
+  uint8_t key1;
+  uint8_t key2;
+} __attribute__((packed));
+
+class Qos final : public Module {
+ public:
+  static const gate_idx_t kNumOGates = MAX_GATES;
+
+  static const Commands cmds;
+
+  Qos() : Module(), default_gate_(), total_key_size_(), fields_() {
+    max_allowed_workers_ = Worker::kMaxWorkers;
+    size_t len = sizeof(mask) / sizeof(uint64_t);
+    for (size_t i = 0; i < len; i++)
+      mask[i] = 0;
+  }
+
+  CommandResponse Init(const bess::pb::QosArg &arg);
+  void ProcessBatch(Context *ctx, bess::PacketBatch *batch) override;
+  CommandResponse CommandAdd(const bess::pb::QosCommandAddArg &arg);
+  CommandResponse CommandDelete(const bess::pb::QosCommandDeleteArg &arg);
+  CommandResponse CommandClear(const bess::pb::EmptyArg &arg);
+  CommandResponse CommandSetDefaultGate(
+      const bess::pb::QosCommandSetDefaultGateArg &arg);
+  template <typename T>
+  CommandResponse ExtractKeyMask(const T &arg, MeteringKey *key,
+                                 MeteringKey *val, MKey *l);
+  template <typename T>
+  CommandResponse ExtractKey(const T &arg, MeteringKey *key);
+  CommandResponse AddFieldOne(const bess::pb::Field &field,
+                              struct MeteringField *f, uint8_t type);
+  gate_idx_t LookupEntry(const MeteringKey &key, gate_idx_t def_gate);
+  void DeInit();
+  std::string GetDesc() const override;
+
+ private:
+  int DelEntry(MeteringKey *key);
+  void Clear();
+  gate_idx_t default_gate_;
+  size_t total_key_size_; /* a multiple of sizeof(uint64_t) */
+  size_t total_value_size_;
+  std::vector<struct MeteringField> fields_;
+  std::vector<struct MeteringField> values_;
+  Metering<value> table_;
+  uint64_t mask[MAX_FIELDS];
+};
+
+#endif  // BESS_MODULES_QOS_H

--- a/core/utils/metering.h
+++ b/core/utils/metering.h
@@ -1,0 +1,218 @@
+// Copyright (c) 2014-2016, The Regents of the University of California.
+// Copyright (c) 2016-2017, Nefeli Networks, Inc.
+// Copyright (c) 2021 Intel Corporation
+// All rights reserved
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// * Neither the names of the copyright holders nor the names of their
+// contributors may be used to endorse or promote products derived from this
+// software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef BESS_UTILS_METERING_H_
+#define BESS_UTILS_METERING_H_
+
+#include <string>
+#include <type_traits>
+#include <vector>
+
+#include "../message.h"
+#include "../metadata.h"
+#include "../module.h"
+#include "../packet.h"
+#include "bits.h"
+#include "cuckoo_map.h"
+#include "endian.h"
+#include "format.h"
+#include <rte_config.h>
+#include <rte_hash_crc.h>
+#include <rte_meter.h>
+
+#define MAX_FIELDS 8
+#define MAX_FIELD_SIZE 8
+
+static_assert(MAX_FIELD_SIZE <= sizeof(uint64_t),
+              "field cannot be larger than 8 bytes");
+
+#define HASH_KEY_SIZE (MAX_FIELDS * MAX_FIELD_SIZE)
+
+#if __BYTE_ORDER__ != __ORDER_LITTLE_ENDIAN__
+#error this code assumes little endian architecture (x86)
+#endif
+
+struct MeteringField {
+  int attr_id;
+  int offset;
+  int pos;
+  int size;
+};
+
+namespace bess {
+namespace utils {
+
+using Error = std::pair<int, std::string>;
+
+struct MeteringKey {
+  uint64_t u64_arr[MAX_FIELDS];
+} __attribute__((packed));
+
+// Equality operator for two MeteringKeys
+class MeteringKeyEq {
+ public:
+  explicit MeteringKeyEq(size_t len) : len_(len) {}
+
+  bool operator()(const MeteringKey &lhs, const MeteringKey &rhs) const {
+    promise(len_ >= sizeof(uint64_t));
+    promise(len_ <= sizeof(MeteringKey));
+
+    for (size_t i = 0; i < len_ / 8; i++) {
+      if (lhs.u64_arr[i] != rhs.u64_arr[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+ private:
+  size_t len_;
+};
+
+// Hash function for an MeteringKey
+class MeteringKeyHash {
+ public:
+  explicit MeteringKeyHash(size_t len) : len_(len) {}
+
+  HashResult operator()(const MeteringKey &key) const {
+    HashResult init_val = 0;
+
+    promise(len_ >= sizeof(uint64_t));
+    promise(len_ <= sizeof(MeteringKey));
+
+#if __x86_64
+    for (size_t i = 0; i < len_ / 8; i++) {
+      init_val = crc32c_sse42_u64(key.u64_arr[i], init_val);
+    }
+    return init_val;
+#else
+    return rte_hash_crc(&key, len_, init_val);
+#endif
+  }
+
+ private:
+  size_t len_;
+};
+
+template <typename T>
+class Metering {
+ public:
+  struct rte_hash_parameters dpdk_params {
+    .name = "Metering", .entries = 1 << 20, .reserved = 0,
+    .key_len = sizeof(MeteringKey), .hash_func = rte_hash_crc,
+    .hash_func_init_val = 0, .socket_id = (int)rte_socket_id(),
+    .extra_flag = RTE_HASH_EXTRA_FLAGS_RW_CONCURRENCY
+  };
+
+  using EmTable = CuckooMap<MeteringKey, T, MeteringKeyHash, MeteringKeyEq>;
+  Metering() : total_key_size_(0), num_fields_(0) {}
+
+  Error Add(const T &val, const MeteringKey &key) {
+    Error err;
+    const void *Key_t = (const void *)&key;
+    T *val_t = new T(val);
+    int ret = table_->insert_dpdk(Key_t, val_t);
+    if (!ret) {
+      return MakeError(ENOENT, "Dpdk Insert Failed");
+    }
+    return MakeError(0);
+  }
+
+  Error Delete(const MeteringKey &key) {
+    Error err;
+    bool ret = table_->Remove(key, MeteringKeyHash(total_key_size_),
+                              MeteringKeyEq(total_key_size_));
+    if (!ret) {
+      return MakeError(ENOENT, "rule doesn't exist");
+    }
+    return MakeError(0);
+  }
+
+  void Clear() { table_->Clear(); }
+  size_t Count() const { return table_->Count(); }
+  void DeInit() { table_->DeInit(); }
+
+  // Find an entry in the table.
+  // Returns the value if `key` matches a rule, otherwise `default_value`.
+  T Find(const MeteringKey &key, const T &default_value) const {
+    const auto &table = table_;
+    void *data = nullptr;
+    table->find_dpdk(&key, &data);
+    if (data) {
+      T data_t = *((T *)data);
+      return data_t;
+    } else
+
+      return default_value;
+  }
+
+  uint64_t Find(MeteringKey *keys, T **vals, int n) {
+    uint64_t hit_mask = 0;
+
+    const auto &table = table_;
+    MeteringKey *key_ptr[n];
+    for (int h = 0; h < n; h++)
+      key_ptr[h] = &keys[h];
+    table->lookup_bulk_data((const void **)&key_ptr, n, &hit_mask,
+                            (void **)vals);
+
+    return hit_mask;
+  }
+
+  uint32_t Total_key_size() const { return total_key_size_; }
+
+  void Init(int size) {
+    std::ostringstream address;
+    total_key_size_ = size;
+    address << &table_;
+    std::string name = "Metering" + address.str();
+    dpdk_params.name = name.c_str();
+    dpdk_params.key_len = size;
+    table_.reset(new CuckooMap<MeteringKey, T, MeteringKeyHash, MeteringKeyEq>(
+        0, 0, &dpdk_params));
+  }
+
+ private:
+  Error MakeError(int code, const std::string &msg = "") {
+    return std::make_pair(code, msg);
+  }
+
+  // aligned total key size
+  size_t total_key_size_;
+  size_t num_fields_;
+  std::unique_ptr<CuckooMap<MeteringKey, T, MeteringKeyHash, MeteringKeyEq>>
+      table_;
+};
+
+}  // namespace utils
+}  // namespace bess
+
+#endif

--- a/patches/bess/0012-Dpdk-concurrent-hash-support-pipeline-improvement.patch
+++ b/patches/bess/0012-Dpdk-concurrent-hash-support-pipeline-improvement.patch
@@ -1,18 +1,20 @@
-From 82a661d06d62d80d43af3c55725539ec77c20583 Mon Sep 17 00:00:00 2001
+From 51109b91cd780bbadbf5bf114f47def55579e2d5 Mon Sep 17 00:00:00 2001
 From: Amar Sri <amarsri28@gmail.com>
-Date: Thu, 10 Jun 2021 02:29:17 -0700
-Subject: [PATCH] bug #282 resolved
+Date: Tue, 3 Aug 2021 09:09:48 -0700
+Subject: [PATCH] DPDK concurrent hash for EM WM
 
+Added DeInit
 ---
- core/modules/exact_match.cc    |  20 ++-
- core/modules/wildcard_match.cc | 242 +++++++++++++++++++++++++--------
- core/modules/wildcard_match.h  |  28 +++-
- core/utils/cuckoo_map.h        | 128 ++++++++++++++++-
- core/utils/exact_match_table.h |  80 ++++++-----
- 5 files changed, 384 insertions(+), 114 deletions(-)
+ core/modules/exact_match.cc    |  24 ++--
+ core/modules/exact_match.h     |   3 +
+ core/modules/wildcard_match.cc | 249 +++++++++++++++++++++++++--------
+ core/modules/wildcard_match.h  |  30 +++-
+ core/utils/cuckoo_map.h        | 137 +++++++++++++++++-
+ core/utils/exact_match_table.h |  82 ++++++-----
+ 6 files changed, 411 insertions(+), 114 deletions(-)
 
 diff --git a/core/modules/exact_match.cc b/core/modules/exact_match.cc
-index 1ca0fd4e..758c0202 100644
+index 1ca0fd4e..22269d0c 100644
 --- a/core/modules/exact_match.cc
 +++ b/core/modules/exact_match.cc
 @@ -134,7 +134,7 @@ CommandResponse ExactMatch::Init(const bess::pb::ExactMatchArg &arg) {
@@ -50,8 +52,31 @@ index 1ca0fd4e..758c0202 100644
    }
  }
  
+@@ -422,4 +420,8 @@ CommandResponse ExactMatch::CommandSetDefaultGate(
+   return CommandSuccess();
+ }
+ 
++void ExactMatch::DeInit() {
++    table_.DeInit();
++}
++
+ ADD_MODULE(ExactMatch, "em", "Multi-field classifier with an exact match table")
+diff --git a/core/modules/exact_match.h b/core/modules/exact_match.h
+index 99cb2654..d7e3531e 100644
+--- a/core/modules/exact_match.h
++++ b/core/modules/exact_match.h
+@@ -90,6 +90,9 @@ class ExactMatch final : public Module {
+   std::string GetDesc() const override;
+ 
+   CommandResponse Init(const bess::pb::ExactMatchArg &arg);
++
++  void DeInit() override;
++
+   CommandResponse GetInitialArg(const bess::pb::EmptyArg &arg);
+   CommandResponse GetRuntimeConfig(const bess::pb::EmptyArg &arg);
+   CommandResponse SetRuntimeConfig(const bess::pb::ExactMatchConfig &arg);
 diff --git a/core/modules/wildcard_match.cc b/core/modules/wildcard_match.cc
-index ec639a7b..f5678905 100644
+index ec639a7b..3c8425e4 100644
 --- a/core/modules/wildcard_match.cc
 +++ b/core/modules/wildcard_match.cc
 @@ -40,13 +40,28 @@ using bess::metadata::Attribute;
@@ -266,7 +291,7 @@ index ec639a7b..f5678905 100644
    }
  
    return bess::utils::Format("%zu fields, %d rules", fields_.size(), num_rules);
-@@ -387,54 +495,62 @@ CommandResponse WildcardMatch::ExtractValue(const T &arg, wm_hkey_t *keyv) {
+@@ -387,54 +495,60 @@ CommandResponse WildcardMatch::ExtractValue(const T &arg, wm_hkey_t *keyv) {
  }
  
  int WildcardMatch::FindTuple(wm_hkey_t *mask) {
@@ -334,8 +359,6 @@ index ec639a7b..f5678905 100644
 -  if (tuple.ht.Count() == 0) {
 -    tuples_.erase(tuples_.begin() + idx);
 +  if (tuples_[idx].ht->Count() == 0) {
-+    tuples_[idx].occupied = 0;
-+    tuples_[idx].ht->Clear();
    }
 -
 -  return true;
@@ -355,7 +378,7 @@ index ec639a7b..f5678905 100644
    CommandResponse err = ExtractKeyMask(arg, &key, &mask);
    if (err.error().code() != 0) {
      return err;
-@@ -444,14 +560,13 @@ CommandResponse WildcardMatch::CommandAdd(
+@@ -444,14 +558,13 @@ CommandResponse WildcardMatch::CommandAdd(
      return CommandFailure(EINVAL, "Invalid gate: %hu", gate);
    }
  
@@ -371,7 +394,7 @@ index ec639a7b..f5678905 100644
    int idx = FindTuple(&mask);
    if (idx < 0) {
      idx = AddTuple(&mask);
-@@ -459,13 +574,10 @@ CommandResponse WildcardMatch::CommandAdd(
+@@ -459,13 +572,10 @@ CommandResponse WildcardMatch::CommandAdd(
        return CommandFailure(-idx, "failed to add a new wildcard pattern");
      }
    }
@@ -388,7 +411,7 @@ index ec639a7b..f5678905 100644
    return CommandSuccess();
  }
  
-@@ -485,7 +597,7 @@ CommandResponse WildcardMatch::CommandDelete(
+@@ -485,7 +595,7 @@ CommandResponse WildcardMatch::CommandDelete(
    }
  
    int ret = DelEntry(idx, &key);
@@ -397,7 +420,7 @@ index ec639a7b..f5678905 100644
      return CommandFailure(-ret, "failed to delete a rule");
    }
  
-@@ -499,7 +611,10 @@ CommandResponse WildcardMatch::CommandClear(const bess::pb::EmptyArg &) {
+@@ -499,7 +609,10 @@ CommandResponse WildcardMatch::CommandClear(const bess::pb::EmptyArg &) {
  
  void WildcardMatch::Clear() {
    for (auto &tuple : tuples_) {
@@ -409,7 +432,7 @@ index ec639a7b..f5678905 100644
    }
  }
  
-@@ -521,17 +636,26 @@ CommandResponse WildcardMatch::GetInitialArg(const bess::pb::EmptyArg &) {
+@@ -521,17 +634,26 @@ CommandResponse WildcardMatch::GetInitialArg(const bess::pb::EmptyArg &) {
  // Retrieves a WildcardMatchConfig that would restore this module's
  // runtime configuration.
  CommandResponse WildcardMatch::GetRuntimeConfig(const bess::pb::EmptyArg &) {
@@ -438,8 +461,23 @@ index ec639a7b..f5678905 100644
        // Create the rule instance
        rule_t *rule = resp.add_rules();
        rule->set_priority(entry.second.priority);
+@@ -596,5 +718,14 @@ CommandResponse WildcardMatch::SetRuntimeConfig(
+   return CommandSuccess();
+ }
+ 
++void WildcardMatch::DeInit() {
++    for (auto &tuple : tuples_) {
++        if (!tuple.ht)
++            continue;
++        tuple.ht->DeInit();
++        tuple.ht = NULL;
++    }
++}
++
+ ADD_MODULE(WildcardMatch, "wm",
+            "Multi-field classifier with a wildcard match table")
 diff --git a/core/modules/wildcard_match.h b/core/modules/wildcard_match.h
-index 85deeafc..b6b2f728 100644
+index 85deeafc..0bd85f6b 100644
 --- a/core/modules/wildcard_match.h
 +++ b/core/modules/wildcard_match.h
 @@ -45,6 +45,7 @@ using bess::utils::HashResult;
@@ -463,7 +501,7 @@ index 85deeafc..b6b2f728 100644
  
  class WildcardMatch final : public Module {
   public:
-@@ -144,6 +151,7 @@ class WildcardMatch final : public Module {
+@@ -144,10 +151,13 @@ class WildcardMatch final : public Module {
          values_(),
          tuples_() {
      max_allowed_workers_ = Worker::kMaxWorkers;
@@ -471,7 +509,13 @@ index 85deeafc..b6b2f728 100644
    }
  
    CommandResponse Init(const bess::pb::WildcardMatchArg &arg);
-@@ -164,13 +172,26 @@ class WildcardMatch final : public Module {
+ 
++  void DeInit() override;
++
+   void ProcessBatch(Context *ctx, bess::PacketBatch *batch) override;
+ 
+   std::string GetDesc() const override;
+@@ -164,13 +174,26 @@ class WildcardMatch final : public Module {
  
   private:
    struct WmTuple {
@@ -499,7 +543,7 @@ index 85deeafc..b6b2f728 100644
    CommandResponse AddFieldOne(const bess::pb::Field &field, struct WmField *f,
                                uint8_t type);
  
-@@ -182,9 +203,7 @@ class WildcardMatch final : public Module {
+@@ -182,9 +205,7 @@ class WildcardMatch final : public Module {
    int FindTuple(wm_hkey_t *mask);
    int AddTuple(wm_hkey_t *mask);
    bool DelEntry(int idx, wm_hkey_t *key);
@@ -509,7 +553,7 @@ index 85deeafc..b6b2f728 100644
    gate_idx_t default_gate_;
  
    size_t total_key_size_;   /* a multiple of sizeof(uint64_t) */
-@@ -193,7 +212,8 @@ class WildcardMatch final : public Module {
+@@ -193,7 +214,8 @@ class WildcardMatch final : public Module {
    // TODO(melvinw): this can be refactored to use ExactMatchTable
    std::vector<struct WmField> fields_;
    std::vector<struct WmField> values_;
@@ -520,7 +564,7 @@ index 85deeafc..b6b2f728 100644
  
  #endif  // BESS_MODULES_WILDCARDMATCH_H_
 diff --git a/core/utils/cuckoo_map.h b/core/utils/cuckoo_map.h
-index c855b93d..b37524e1 100644
+index c855b93d..9a66864d 100644
 --- a/core/utils/cuckoo_map.h
 +++ b/core/utils/cuckoo_map.h
 @@ -50,6 +50,8 @@
@@ -681,21 +725,20 @@ index c855b93d..b37524e1 100644
      HashResult pri = Hash(key, hasher);
      if (RemoveFromBucket(pri, pri & bucket_mask_, key, eq)) {
        return true;
-@@ -267,6 +355,13 @@ class CuckooMap {
+@@ -267,6 +355,12 @@ class CuckooMap {
    }
  
    void Clear() {
 +    if (IsDpdk) {
 +      if (hash) {
-+        rte_hash_free(hash);
-+        hash = nullptr;
++        rte_hash_reset(hash);
 +      }
 +      return;
 +    }
      buckets_.clear();
      entries_.clear();
  
-@@ -286,7 +381,26 @@ class CuckooMap {
+@@ -286,7 +380,36 @@ class CuckooMap {
    }
  
    // Return the number of stored entries
@@ -705,6 +748,16 @@ index c855b93d..b37524e1 100644
 +      return rte_hash_count(hash);
 +    else
 +      return num_entries_;
++  }
++
++  void DeInit() {
++    if (IsDpdk) {
++      if (hash) {
++        rte_hash_free(hash);
++        hash = nullptr;
++      }
++      return;
++    }
 +  }
 +
 +  // bulk data look up bess func
@@ -724,7 +777,7 @@ index c855b93d..b37524e1 100644
   protected:
    // Tunable macros
 diff --git a/core/utils/exact_match_table.h b/core/utils/exact_match_table.h
-index 7c0cfda4..e6d909f5 100644
+index 7c0cfda4..ac87e090 100644
 --- a/core/utils/exact_match_table.h
 +++ b/core/utils/exact_match_table.h
 @@ -155,15 +155,17 @@ typedef std::vector<std::vector<uint8_t>> ExactMatchRuleFields;
@@ -776,7 +829,7 @@ index 7c0cfda4..e6d909f5 100644
      if (!ret) {
        return MakeError(ENOENT, "rule doesn't exist");
      }
-@@ -217,9 +218,9 @@ class ExactMatchTable {
+@@ -217,9 +218,11 @@ class ExactMatchTable {
    }
  
    // Remove all rules from the table.
@@ -784,11 +837,13 @@ index 7c0cfda4..e6d909f5 100644
 +  void ClearRules() { table_->Clear(); }
  
 -  size_t Size() const { return table_.Count(); }
++  void DeInit() { table_->DeInit(); }
++
 +  size_t Size() const { return table_->Count(); }
  
    // Extract an ExactMatchKey from `buf` based on the fields that have been
    // added to this table.
-@@ -272,23 +273,27 @@ class ExactMatchTable {
+@@ -272,23 +275,27 @@ class ExactMatchTable {
    // Returns the value if `key` matches a rule, otherwise `default_value`.
    T Find(const ExactMatchKey &key, const T &default_value) const {
      const auto &table = table_;
@@ -827,16 +882,16 @@ index 7c0cfda4..e6d909f5 100644
    }
  
    uint32_t total_key_size() const { return total_key_size_; }
-@@ -318,9 +323,20 @@ class ExactMatchTable {
+@@ -318,9 +325,20 @@ class ExactMatchTable {
    // Returns the ith field.
    const ExactMatchField &get_field(size_t i) const { return fields_[i]; }
  
 -  typename EmTable::iterator begin() { return table_.begin(); }
 +  typename EmTable::iterator begin() { return table_->begin(); }
-+
-+  typename EmTable::iterator end() { return table_->end(); }
  
 -  typename EmTable::iterator end() { return table_.end(); }
++  typename EmTable::iterator end() { return table_->end(); }
++
 +  void Init() {
 +    std::ostringstream address;
 +    address << &table_;
@@ -850,7 +905,7 @@ index 7c0cfda4..e6d909f5 100644
  
   private:
    Error MakeError(int code, const std::string &msg = "") {
-@@ -438,23 +454,21 @@ class ExactMatchTable {
+@@ -438,23 +456,21 @@ class ExactMatchTable {
      f->pos = raw_key_size_;
      raw_key_size_ += f->size;
      total_key_size_ = align_ceil(raw_key_size_, sizeof(uint64_t));

--- a/patches/bess/0015-Protobuf-changes-for-Qos.patch
+++ b/patches/bess/0015-Protobuf-changes-for-Qos.patch
@@ -1,0 +1,55 @@
+From 4b459fb183b66517ae724fa37b4344af4cda8851 Mon Sep 17 00:00:00 2001
+From: Amar Sri <amarsri28@gmail.com>
+Date: Thu, 12 Aug 2021 03:16:10 -0700
+Subject: [PATCH] Protobuf changes for Qos.cc
+
+---
+ protobuf/module_msg.proto | 35 +++++++++++++++++++++++++++++++++++
+ 1 file changed, 35 insertions(+)
+
+diff --git a/protobuf/module_msg.proto b/protobuf/module_msg.proto
+index 25dfc81e..1f7058cd 100644
+--- a/protobuf/module_msg.proto
++++ b/protobuf/module_msg.proto
+@@ -1291,3 +1291,38 @@ message MplsPopArg {
+ message WorkerSplitArg {
+   map<uint32, uint32> worker_gates = 1; // ogate -> worker mask
+ }
++
++message QosArg {
++  repeated Field fields = 1;
++  repeated Field values = 2;
++}
++
++message QosCommandAddArg {
++  uint64 gate = 1;
++  uint64 cir = 2;
++  uint64 pir = 3;
++  uint64 cbs = 4;
++  uint64 pbs = 5;
++  uint64 ebs = 6;
++  repeated FieldData fields = 7;
++  repeated FieldData values = 8;
++}
++
++message QosCommandDeleteArg {
++  repeated FieldData fields = 2;
++}
++
++/**
++ * The function `clear()` for WildcardMatch takes no parameters, it clears
++ * all state in the WildcardMatch module (is equivalent to calling delete for all rules)
++ */
++message QosCommandClearArg {
++}
++
++/**
++ * For traffic which does not match any rule in the WildcardMatch module,
++ * the `set_default_gate(...)` function specifies which gate to send this extra traffic to.
++ */
++message QosCommandSetDefaultGateArg {
++  uint64 gate = 1;
++}
+-- 
+2.17.1
+

--- a/pfcpiface/bess_pb/module_msg.pb.go
+++ b/pfcpiface/bess_pb/module_msg.pb.go
@@ -5895,6 +5895,302 @@ func (x *WorkerSplitArg) GetWorkerGates() map[uint32]uint32 {
 	return nil
 }
 
+type QosArg struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Fields []*Field `protobuf:"bytes,1,rep,name=fields,proto3" json:"fields,omitempty"`
+	Values []*Field `protobuf:"bytes,2,rep,name=values,proto3" json:"values,omitempty"`
+}
+
+func (x *QosArg) Reset() {
+	*x = QosArg{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_module_msg_proto_msgTypes[102]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *QosArg) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*QosArg) ProtoMessage() {}
+
+func (x *QosArg) ProtoReflect() protoreflect.Message {
+	mi := &file_module_msg_proto_msgTypes[102]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use QosArg.ProtoReflect.Descriptor instead.
+func (*QosArg) Descriptor() ([]byte, []int) {
+	return file_module_msg_proto_rawDescGZIP(), []int{102}
+}
+
+func (x *QosArg) GetFields() []*Field {
+	if x != nil {
+		return x.Fields
+	}
+	return nil
+}
+
+func (x *QosArg) GetValues() []*Field {
+	if x != nil {
+		return x.Values
+	}
+	return nil
+}
+
+type QosCommandAddArg struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Gate   uint64       `protobuf:"varint,1,opt,name=gate,proto3" json:"gate,omitempty"`
+	Cir    uint64       `protobuf:"varint,2,opt,name=cir,proto3" json:"cir,omitempty"`
+	Pir    uint64       `protobuf:"varint,3,opt,name=pir,proto3" json:"pir,omitempty"`
+	Cbs    uint64       `protobuf:"varint,4,opt,name=cbs,proto3" json:"cbs,omitempty"`
+	Pbs    uint64       `protobuf:"varint,5,opt,name=pbs,proto3" json:"pbs,omitempty"`
+	Ebs    uint64       `protobuf:"varint,6,opt,name=ebs,proto3" json:"ebs,omitempty"`
+	Fields []*FieldData `protobuf:"bytes,7,rep,name=fields,proto3" json:"fields,omitempty"`
+	Values []*FieldData `protobuf:"bytes,8,rep,name=values,proto3" json:"values,omitempty"`
+}
+
+func (x *QosCommandAddArg) Reset() {
+	*x = QosCommandAddArg{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_module_msg_proto_msgTypes[103]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *QosCommandAddArg) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*QosCommandAddArg) ProtoMessage() {}
+
+func (x *QosCommandAddArg) ProtoReflect() protoreflect.Message {
+	mi := &file_module_msg_proto_msgTypes[103]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use QosCommandAddArg.ProtoReflect.Descriptor instead.
+func (*QosCommandAddArg) Descriptor() ([]byte, []int) {
+	return file_module_msg_proto_rawDescGZIP(), []int{103}
+}
+
+func (x *QosCommandAddArg) GetGate() uint64 {
+	if x != nil {
+		return x.Gate
+	}
+	return 0
+}
+
+func (x *QosCommandAddArg) GetCir() uint64 {
+	if x != nil {
+		return x.Cir
+	}
+	return 0
+}
+
+func (x *QosCommandAddArg) GetPir() uint64 {
+	if x != nil {
+		return x.Pir
+	}
+	return 0
+}
+
+func (x *QosCommandAddArg) GetCbs() uint64 {
+	if x != nil {
+		return x.Cbs
+	}
+	return 0
+}
+
+func (x *QosCommandAddArg) GetPbs() uint64 {
+	if x != nil {
+		return x.Pbs
+	}
+	return 0
+}
+
+func (x *QosCommandAddArg) GetEbs() uint64 {
+	if x != nil {
+		return x.Ebs
+	}
+	return 0
+}
+
+func (x *QosCommandAddArg) GetFields() []*FieldData {
+	if x != nil {
+		return x.Fields
+	}
+	return nil
+}
+
+func (x *QosCommandAddArg) GetValues() []*FieldData {
+	if x != nil {
+		return x.Values
+	}
+	return nil
+}
+
+type QosCommandDeleteArg struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Fields []*FieldData `protobuf:"bytes,2,rep,name=fields,proto3" json:"fields,omitempty"`
+}
+
+func (x *QosCommandDeleteArg) Reset() {
+	*x = QosCommandDeleteArg{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_module_msg_proto_msgTypes[104]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *QosCommandDeleteArg) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*QosCommandDeleteArg) ProtoMessage() {}
+
+func (x *QosCommandDeleteArg) ProtoReflect() protoreflect.Message {
+	mi := &file_module_msg_proto_msgTypes[104]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use QosCommandDeleteArg.ProtoReflect.Descriptor instead.
+func (*QosCommandDeleteArg) Descriptor() ([]byte, []int) {
+	return file_module_msg_proto_rawDescGZIP(), []int{104}
+}
+
+func (x *QosCommandDeleteArg) GetFields() []*FieldData {
+	if x != nil {
+		return x.Fields
+	}
+	return nil
+}
+
+//*
+// The function `clear()` for WildcardMatch takes no parameters, it clears
+// all state in the WildcardMatch module (is equivalent to calling delete for all rules)
+type QosCommandClearArg struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+}
+
+func (x *QosCommandClearArg) Reset() {
+	*x = QosCommandClearArg{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_module_msg_proto_msgTypes[105]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *QosCommandClearArg) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*QosCommandClearArg) ProtoMessage() {}
+
+func (x *QosCommandClearArg) ProtoReflect() protoreflect.Message {
+	mi := &file_module_msg_proto_msgTypes[105]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use QosCommandClearArg.ProtoReflect.Descriptor instead.
+func (*QosCommandClearArg) Descriptor() ([]byte, []int) {
+	return file_module_msg_proto_rawDescGZIP(), []int{105}
+}
+
+//*
+// For traffic which does not match any rule in the WildcardMatch module,
+// the `set_default_gate(...)` function specifies which gate to send this extra traffic to.
+type QosCommandSetDefaultGateArg struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Gate uint64 `protobuf:"varint,1,opt,name=gate,proto3" json:"gate,omitempty"`
+}
+
+func (x *QosCommandSetDefaultGateArg) Reset() {
+	*x = QosCommandSetDefaultGateArg{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_module_msg_proto_msgTypes[106]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *QosCommandSetDefaultGateArg) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*QosCommandSetDefaultGateArg) ProtoMessage() {}
+
+func (x *QosCommandSetDefaultGateArg) ProtoReflect() protoreflect.Message {
+	mi := &file_module_msg_proto_msgTypes[106]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use QosCommandSetDefaultGateArg.ProtoReflect.Descriptor instead.
+func (*QosCommandSetDefaultGateArg) Descriptor() ([]byte, []int) {
+	return file_module_msg_proto_rawDescGZIP(), []int{106}
+}
+
+func (x *QosCommandSetDefaultGateArg) GetGate() uint64 {
+	if x != nil {
+		return x.Gate
+	}
+	return 0
+}
+
 type L2ForwardCommandAddArg_Entry struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -5907,7 +6203,7 @@ type L2ForwardCommandAddArg_Entry struct {
 func (x *L2ForwardCommandAddArg_Entry) Reset() {
 	*x = L2ForwardCommandAddArg_Entry{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_module_msg_proto_msgTypes[102]
+		mi := &file_module_msg_proto_msgTypes[107]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -5920,7 +6216,7 @@ func (x *L2ForwardCommandAddArg_Entry) String() string {
 func (*L2ForwardCommandAddArg_Entry) ProtoMessage() {}
 
 func (x *L2ForwardCommandAddArg_Entry) ProtoReflect() protoreflect.Message {
-	mi := &file_module_msg_proto_msgTypes[102]
+	mi := &file_module_msg_proto_msgTypes[107]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5968,7 +6264,7 @@ type MeasureCommandGetSummaryResponse_Histogram struct {
 func (x *MeasureCommandGetSummaryResponse_Histogram) Reset() {
 	*x = MeasureCommandGetSummaryResponse_Histogram{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_module_msg_proto_msgTypes[103]
+		mi := &file_module_msg_proto_msgTypes[108]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -5981,7 +6277,7 @@ func (x *MeasureCommandGetSummaryResponse_Histogram) String() string {
 func (*MeasureCommandGetSummaryResponse_Histogram) ProtoMessage() {}
 
 func (x *MeasureCommandGetSummaryResponse_Histogram) ProtoReflect() protoreflect.Message {
-	mi := &file_module_msg_proto_msgTypes[103]
+	mi := &file_module_msg_proto_msgTypes[108]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6071,7 +6367,7 @@ type ACLArg_Rule struct {
 func (x *ACLArg_Rule) Reset() {
 	*x = ACLArg_Rule{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_module_msg_proto_msgTypes[104]
+		mi := &file_module_msg_proto_msgTypes[109]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -6084,7 +6380,7 @@ func (x *ACLArg_Rule) String() string {
 func (*ACLArg_Rule) ProtoMessage() {}
 
 func (x *ACLArg_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_module_msg_proto_msgTypes[104]
+	mi := &file_module_msg_proto_msgTypes[109]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6157,7 +6453,7 @@ type BPFArg_Filter struct {
 func (x *BPFArg_Filter) Reset() {
 	*x = BPFArg_Filter{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_module_msg_proto_msgTypes[105]
+		mi := &file_module_msg_proto_msgTypes[110]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -6170,7 +6466,7 @@ func (x *BPFArg_Filter) String() string {
 func (*BPFArg_Filter) ProtoMessage() {}
 
 func (x *BPFArg_Filter) ProtoReflect() protoreflect.Message {
-	mi := &file_module_msg_proto_msgTypes[105]
+	mi := &file_module_msg_proto_msgTypes[110]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6224,7 +6520,7 @@ type GenericEncapArg_EncapField struct {
 func (x *GenericEncapArg_EncapField) Reset() {
 	*x = GenericEncapArg_EncapField{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_module_msg_proto_msgTypes[106]
+		mi := &file_module_msg_proto_msgTypes[111]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -6237,7 +6533,7 @@ func (x *GenericEncapArg_EncapField) String() string {
 func (*GenericEncapArg_EncapField) ProtoMessage() {}
 
 func (x *GenericEncapArg_EncapField) ProtoReflect() protoreflect.Message {
-	mi := &file_module_msg_proto_msgTypes[106]
+	mi := &file_module_msg_proto_msgTypes[111]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6310,7 +6606,7 @@ type NATArg_PortRange struct {
 func (x *NATArg_PortRange) Reset() {
 	*x = NATArg_PortRange{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_module_msg_proto_msgTypes[110]
+		mi := &file_module_msg_proto_msgTypes[115]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -6323,7 +6619,7 @@ func (x *NATArg_PortRange) String() string {
 func (*NATArg_PortRange) ProtoMessage() {}
 
 func (x *NATArg_PortRange) ProtoReflect() protoreflect.Message {
-	mi := &file_module_msg_proto_msgTypes[110]
+	mi := &file_module_msg_proto_msgTypes[115]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6372,7 +6668,7 @@ type NATArg_ExternalAddress struct {
 func (x *NATArg_ExternalAddress) Reset() {
 	*x = NATArg_ExternalAddress{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_module_msg_proto_msgTypes[111]
+		mi := &file_module_msg_proto_msgTypes[116]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -6385,7 +6681,7 @@ func (x *NATArg_ExternalAddress) String() string {
 func (*NATArg_ExternalAddress) ProtoMessage() {}
 
 func (x *NATArg_ExternalAddress) ProtoReflect() protoreflect.Message {
-	mi := &file_module_msg_proto_msgTypes[111]
+	mi := &file_module_msg_proto_msgTypes[116]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6427,7 +6723,7 @@ type StaticNATArg_AddressRange struct {
 func (x *StaticNATArg_AddressRange) Reset() {
 	*x = StaticNATArg_AddressRange{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_module_msg_proto_msgTypes[112]
+		mi := &file_module_msg_proto_msgTypes[117]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -6440,7 +6736,7 @@ func (x *StaticNATArg_AddressRange) String() string {
 func (*StaticNATArg_AddressRange) ProtoMessage() {}
 
 func (x *StaticNATArg_AddressRange) ProtoReflect() protoreflect.Message {
-	mi := &file_module_msg_proto_msgTypes[112]
+	mi := &file_module_msg_proto_msgTypes[117]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6482,7 +6778,7 @@ type StaticNATArg_AddressRangePair struct {
 func (x *StaticNATArg_AddressRangePair) Reset() {
 	*x = StaticNATArg_AddressRangePair{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_module_msg_proto_msgTypes[113]
+		mi := &file_module_msg_proto_msgTypes[118]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -6495,7 +6791,7 @@ func (x *StaticNATArg_AddressRangePair) String() string {
 func (*StaticNATArg_AddressRangePair) ProtoMessage() {}
 
 func (x *StaticNATArg_AddressRangePair) ProtoReflect() protoreflect.Message {
-	mi := &file_module_msg_proto_msgTypes[113]
+	mi := &file_module_msg_proto_msgTypes[118]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6542,7 +6838,7 @@ type RandomUpdateArg_Field struct {
 func (x *RandomUpdateArg_Field) Reset() {
 	*x = RandomUpdateArg_Field{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_module_msg_proto_msgTypes[114]
+		mi := &file_module_msg_proto_msgTypes[119]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -6555,7 +6851,7 @@ func (x *RandomUpdateArg_Field) String() string {
 func (*RandomUpdateArg_Field) ProtoMessage() {}
 
 func (x *RandomUpdateArg_Field) ProtoReflect() protoreflect.Message {
-	mi := &file_module_msg_proto_msgTypes[114]
+	mi := &file_module_msg_proto_msgTypes[119]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6623,7 +6919,7 @@ type SetMetadataArg_Attribute struct {
 func (x *SetMetadataArg_Attribute) Reset() {
 	*x = SetMetadataArg_Attribute{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_module_msg_proto_msgTypes[115]
+		mi := &file_module_msg_proto_msgTypes[120]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -6636,7 +6932,7 @@ func (x *SetMetadataArg_Attribute) String() string {
 func (*SetMetadataArg_Attribute) ProtoMessage() {}
 
 func (x *SetMetadataArg_Attribute) ProtoReflect() protoreflect.Message {
-	mi := &file_module_msg_proto_msgTypes[115]
+	mi := &file_module_msg_proto_msgTypes[120]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6739,7 +7035,7 @@ type UpdateArg_Field struct {
 func (x *UpdateArg_Field) Reset() {
 	*x = UpdateArg_Field{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_module_msg_proto_msgTypes[116]
+		mi := &file_module_msg_proto_msgTypes[121]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -6752,7 +7048,7 @@ func (x *UpdateArg_Field) String() string {
 func (*UpdateArg_Field) ProtoMessage() {}
 
 func (x *UpdateArg_Field) ProtoReflect() protoreflect.Message {
-	mi := &file_module_msg_proto_msgTypes[116]
+	mi := &file_module_msg_proto_msgTypes[121]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6803,7 +7099,7 @@ type UrlFilterArg_Url struct {
 func (x *UrlFilterArg_Url) Reset() {
 	*x = UrlFilterArg_Url{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_module_msg_proto_msgTypes[117]
+		mi := &file_module_msg_proto_msgTypes[122]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -6816,7 +7112,7 @@ func (x *UrlFilterArg_Url) String() string {
 func (*UrlFilterArg_Url) ProtoMessage() {}
 
 func (x *UrlFilterArg_Url) ProtoReflect() protoreflect.Message {
-	mi := &file_module_msg_proto_msgTypes[117]
+	mi := &file_module_msg_proto_msgTypes[122]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7408,7 +7704,36 @@ var file_module_msg_proto_rawDesc = []byte{
 	0x65, 0x72, 0x47, 0x61, 0x74, 0x65, 0x73, 0x45, 0x6e, 0x74, 0x72, 0x79, 0x12, 0x10, 0x0a, 0x03,
 	0x6b, 0x65, 0x79, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0d, 0x52, 0x03, 0x6b, 0x65, 0x79, 0x12, 0x14,
 	0x0a, 0x05, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0d, 0x52, 0x05, 0x76,
-	0x61, 0x6c, 0x75, 0x65, 0x3a, 0x02, 0x38, 0x01, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
+	0x61, 0x6c, 0x75, 0x65, 0x3a, 0x02, 0x38, 0x01, 0x22, 0x58, 0x0a, 0x06, 0x51, 0x6f, 0x73, 0x41,
+	0x72, 0x67, 0x12, 0x26, 0x0a, 0x06, 0x66, 0x69, 0x65, 0x6c, 0x64, 0x73, 0x18, 0x01, 0x20, 0x03,
+	0x28, 0x0b, 0x32, 0x0e, 0x2e, 0x62, 0x65, 0x73, 0x73, 0x2e, 0x70, 0x62, 0x2e, 0x46, 0x69, 0x65,
+	0x6c, 0x64, 0x52, 0x06, 0x66, 0x69, 0x65, 0x6c, 0x64, 0x73, 0x12, 0x26, 0x0a, 0x06, 0x76, 0x61,
+	0x6c, 0x75, 0x65, 0x73, 0x18, 0x02, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x0e, 0x2e, 0x62, 0x65, 0x73,
+	0x73, 0x2e, 0x70, 0x62, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x52, 0x06, 0x76, 0x61, 0x6c, 0x75,
+	0x65, 0x73, 0x22, 0xd8, 0x01, 0x0a, 0x10, 0x51, 0x6f, 0x73, 0x43, 0x6f, 0x6d, 0x6d, 0x61, 0x6e,
+	0x64, 0x41, 0x64, 0x64, 0x41, 0x72, 0x67, 0x12, 0x12, 0x0a, 0x04, 0x67, 0x61, 0x74, 0x65, 0x18,
+	0x01, 0x20, 0x01, 0x28, 0x04, 0x52, 0x04, 0x67, 0x61, 0x74, 0x65, 0x12, 0x10, 0x0a, 0x03, 0x63,
+	0x69, 0x72, 0x18, 0x02, 0x20, 0x01, 0x28, 0x04, 0x52, 0x03, 0x63, 0x69, 0x72, 0x12, 0x10, 0x0a,
+	0x03, 0x70, 0x69, 0x72, 0x18, 0x03, 0x20, 0x01, 0x28, 0x04, 0x52, 0x03, 0x70, 0x69, 0x72, 0x12,
+	0x10, 0x0a, 0x03, 0x63, 0x62, 0x73, 0x18, 0x04, 0x20, 0x01, 0x28, 0x04, 0x52, 0x03, 0x63, 0x62,
+	0x73, 0x12, 0x10, 0x0a, 0x03, 0x70, 0x62, 0x73, 0x18, 0x05, 0x20, 0x01, 0x28, 0x04, 0x52, 0x03,
+	0x70, 0x62, 0x73, 0x12, 0x10, 0x0a, 0x03, 0x65, 0x62, 0x73, 0x18, 0x06, 0x20, 0x01, 0x28, 0x04,
+	0x52, 0x03, 0x65, 0x62, 0x73, 0x12, 0x2a, 0x0a, 0x06, 0x66, 0x69, 0x65, 0x6c, 0x64, 0x73, 0x18,
+	0x07, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x12, 0x2e, 0x62, 0x65, 0x73, 0x73, 0x2e, 0x70, 0x62, 0x2e,
+	0x46, 0x69, 0x65, 0x6c, 0x64, 0x44, 0x61, 0x74, 0x61, 0x52, 0x06, 0x66, 0x69, 0x65, 0x6c, 0x64,
+	0x73, 0x12, 0x2a, 0x0a, 0x06, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x73, 0x18, 0x08, 0x20, 0x03, 0x28,
+	0x0b, 0x32, 0x12, 0x2e, 0x62, 0x65, 0x73, 0x73, 0x2e, 0x70, 0x62, 0x2e, 0x46, 0x69, 0x65, 0x6c,
+	0x64, 0x44, 0x61, 0x74, 0x61, 0x52, 0x06, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x73, 0x22, 0x41, 0x0a,
+	0x13, 0x51, 0x6f, 0x73, 0x43, 0x6f, 0x6d, 0x6d, 0x61, 0x6e, 0x64, 0x44, 0x65, 0x6c, 0x65, 0x74,
+	0x65, 0x41, 0x72, 0x67, 0x12, 0x2a, 0x0a, 0x06, 0x66, 0x69, 0x65, 0x6c, 0x64, 0x73, 0x18, 0x02,
+	0x20, 0x03, 0x28, 0x0b, 0x32, 0x12, 0x2e, 0x62, 0x65, 0x73, 0x73, 0x2e, 0x70, 0x62, 0x2e, 0x46,
+	0x69, 0x65, 0x6c, 0x64, 0x44, 0x61, 0x74, 0x61, 0x52, 0x06, 0x66, 0x69, 0x65, 0x6c, 0x64, 0x73,
+	0x22, 0x14, 0x0a, 0x12, 0x51, 0x6f, 0x73, 0x43, 0x6f, 0x6d, 0x6d, 0x61, 0x6e, 0x64, 0x43, 0x6c,
+	0x65, 0x61, 0x72, 0x41, 0x72, 0x67, 0x22, 0x31, 0x0a, 0x1b, 0x51, 0x6f, 0x73, 0x43, 0x6f, 0x6d,
+	0x6d, 0x61, 0x6e, 0x64, 0x53, 0x65, 0x74, 0x44, 0x65, 0x66, 0x61, 0x75, 0x6c, 0x74, 0x47, 0x61,
+	0x74, 0x65, 0x41, 0x72, 0x67, 0x12, 0x12, 0x0a, 0x04, 0x67, 0x61, 0x74, 0x65, 0x18, 0x01, 0x20,
+	0x01, 0x28, 0x04, 0x52, 0x04, 0x67, 0x61, 0x74, 0x65, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f,
+	0x33,
 }
 
 var (
@@ -7423,7 +7748,7 @@ func file_module_msg_proto_rawDescGZIP() []byte {
 	return file_module_msg_proto_rawDescData
 }
 
-var file_module_msg_proto_msgTypes = make([]protoimpl.MessageInfo, 119)
+var file_module_msg_proto_msgTypes = make([]protoimpl.MessageInfo, 124)
 var file_module_msg_proto_goTypes = []interface{}{
 	(*EmptyArg)(nil),                                   // 0: bess.pb.EmptyArg
 	(*BPFCommandClearArg)(nil),                         // 1: bess.pb.BPFCommandClearArg
@@ -7527,71 +7852,81 @@ var file_module_msg_proto_goTypes = []interface{}{
 	(*ArpResponderArg)(nil),                            // 99: bess.pb.ArpResponderArg
 	(*MplsPopArg)(nil),                                 // 100: bess.pb.MplsPopArg
 	(*WorkerSplitArg)(nil),                             // 101: bess.pb.WorkerSplitArg
-	(*L2ForwardCommandAddArg_Entry)(nil),               // 102: bess.pb.L2ForwardCommandAddArg.Entry
-	(*MeasureCommandGetSummaryResponse_Histogram)(nil), // 103: bess.pb.MeasureCommandGetSummaryResponse.Histogram
-	(*ACLArg_Rule)(nil),                                // 104: bess.pb.ACLArg.Rule
-	(*BPFArg_Filter)(nil),                              // 105: bess.pb.BPFArg.Filter
-	(*GenericEncapArg_EncapField)(nil),                 // 106: bess.pb.GenericEncapArg.EncapField
-	nil,                                                // 107: bess.pb.MetadataTestArg.ReadEntry
-	nil,                                                // 108: bess.pb.MetadataTestArg.WriteEntry
-	nil,                                                // 109: bess.pb.MetadataTestArg.UpdateEntry
-	(*NATArg_PortRange)(nil),                           // 110: bess.pb.NATArg.PortRange
-	(*NATArg_ExternalAddress)(nil),                     // 111: bess.pb.NATArg.ExternalAddress
-	(*StaticNATArg_AddressRange)(nil),                  // 112: bess.pb.StaticNATArg.AddressRange
-	(*StaticNATArg_AddressRangePair)(nil),              // 113: bess.pb.StaticNATArg.AddressRangePair
-	(*RandomUpdateArg_Field)(nil),                      // 114: bess.pb.RandomUpdateArg.Field
-	(*SetMetadataArg_Attribute)(nil),                   // 115: bess.pb.SetMetadataArg.Attribute
-	(*UpdateArg_Field)(nil),                            // 116: bess.pb.UpdateArg.Field
-	(*UrlFilterArg_Url)(nil),                           // 117: bess.pb.UrlFilterArg.Url
-	nil,                                                // 118: bess.pb.WorkerSplitArg.WorkerGatesEntry
-	(*FieldData)(nil),                                  // 119: bess.pb.FieldData
-	(*Field)(nil),                                      // 120: bess.pb.Field
+	(*QosArg)(nil),                                     // 102: bess.pb.QosArg
+	(*QosCommandAddArg)(nil),                           // 103: bess.pb.QosCommandAddArg
+	(*QosCommandDeleteArg)(nil),                        // 104: bess.pb.QosCommandDeleteArg
+	(*QosCommandClearArg)(nil),                         // 105: bess.pb.QosCommandClearArg
+	(*QosCommandSetDefaultGateArg)(nil),                // 106: bess.pb.QosCommandSetDefaultGateArg
+	(*L2ForwardCommandAddArg_Entry)(nil),               // 107: bess.pb.L2ForwardCommandAddArg.Entry
+	(*MeasureCommandGetSummaryResponse_Histogram)(nil), // 108: bess.pb.MeasureCommandGetSummaryResponse.Histogram
+	(*ACLArg_Rule)(nil),                                // 109: bess.pb.ACLArg.Rule
+	(*BPFArg_Filter)(nil),                              // 110: bess.pb.BPFArg.Filter
+	(*GenericEncapArg_EncapField)(nil),                 // 111: bess.pb.GenericEncapArg.EncapField
+	nil,                                                // 112: bess.pb.MetadataTestArg.ReadEntry
+	nil,                                                // 113: bess.pb.MetadataTestArg.WriteEntry
+	nil,                                                // 114: bess.pb.MetadataTestArg.UpdateEntry
+	(*NATArg_PortRange)(nil),                           // 115: bess.pb.NATArg.PortRange
+	(*NATArg_ExternalAddress)(nil),                     // 116: bess.pb.NATArg.ExternalAddress
+	(*StaticNATArg_AddressRange)(nil),                  // 117: bess.pb.StaticNATArg.AddressRange
+	(*StaticNATArg_AddressRangePair)(nil),              // 118: bess.pb.StaticNATArg.AddressRangePair
+	(*RandomUpdateArg_Field)(nil),                      // 119: bess.pb.RandomUpdateArg.Field
+	(*SetMetadataArg_Attribute)(nil),                   // 120: bess.pb.SetMetadataArg.Attribute
+	(*UpdateArg_Field)(nil),                            // 121: bess.pb.UpdateArg.Field
+	(*UrlFilterArg_Url)(nil),                           // 122: bess.pb.UrlFilterArg.Url
+	nil,                                                // 123: bess.pb.WorkerSplitArg.WorkerGatesEntry
+	(*FieldData)(nil),                                  // 124: bess.pb.FieldData
+	(*Field)(nil),                                      // 125: bess.pb.Field
 }
 var file_module_msg_proto_depIdxs = []int32{
-	119, // 0: bess.pb.ExactMatchCommandAddArg.fields:type_name -> bess.pb.FieldData
-	119, // 1: bess.pb.ExactMatchCommandAddArg.values:type_name -> bess.pb.FieldData
-	119, // 2: bess.pb.ExactMatchCommandDeleteArg.fields:type_name -> bess.pb.FieldData
-	120, // 3: bess.pb.HashLBCommandSetModeArg.fields:type_name -> bess.pb.Field
-	102, // 4: bess.pb.L2ForwardCommandAddArg.entries:type_name -> bess.pb.L2ForwardCommandAddArg.Entry
-	103, // 5: bess.pb.MeasureCommandGetSummaryResponse.latency:type_name -> bess.pb.MeasureCommandGetSummaryResponse.Histogram
-	103, // 6: bess.pb.MeasureCommandGetSummaryResponse.jitter:type_name -> bess.pb.MeasureCommandGetSummaryResponse.Histogram
-	119, // 7: bess.pb.WildcardMatchCommandAddArg.values:type_name -> bess.pb.FieldData
-	119, // 8: bess.pb.WildcardMatchCommandAddArg.masks:type_name -> bess.pb.FieldData
-	119, // 9: bess.pb.WildcardMatchCommandAddArg.valuesv:type_name -> bess.pb.FieldData
-	119, // 10: bess.pb.WildcardMatchCommandDeleteArg.values:type_name -> bess.pb.FieldData
-	119, // 11: bess.pb.WildcardMatchCommandDeleteArg.masks:type_name -> bess.pb.FieldData
-	104, // 12: bess.pb.ACLArg.rules:type_name -> bess.pb.ACLArg.Rule
-	105, // 13: bess.pb.BPFArg.filters:type_name -> bess.pb.BPFArg.Filter
-	120, // 14: bess.pb.ExactMatchArg.fields:type_name -> bess.pb.Field
-	119, // 15: bess.pb.ExactMatchArg.masks:type_name -> bess.pb.FieldData
-	120, // 16: bess.pb.ExactMatchArg.values:type_name -> bess.pb.Field
-	119, // 17: bess.pb.ExactMatchArg.masksv:type_name -> bess.pb.FieldData
+	124, // 0: bess.pb.ExactMatchCommandAddArg.fields:type_name -> bess.pb.FieldData
+	124, // 1: bess.pb.ExactMatchCommandAddArg.values:type_name -> bess.pb.FieldData
+	124, // 2: bess.pb.ExactMatchCommandDeleteArg.fields:type_name -> bess.pb.FieldData
+	125, // 3: bess.pb.HashLBCommandSetModeArg.fields:type_name -> bess.pb.Field
+	107, // 4: bess.pb.L2ForwardCommandAddArg.entries:type_name -> bess.pb.L2ForwardCommandAddArg.Entry
+	108, // 5: bess.pb.MeasureCommandGetSummaryResponse.latency:type_name -> bess.pb.MeasureCommandGetSummaryResponse.Histogram
+	108, // 6: bess.pb.MeasureCommandGetSummaryResponse.jitter:type_name -> bess.pb.MeasureCommandGetSummaryResponse.Histogram
+	124, // 7: bess.pb.WildcardMatchCommandAddArg.values:type_name -> bess.pb.FieldData
+	124, // 8: bess.pb.WildcardMatchCommandAddArg.masks:type_name -> bess.pb.FieldData
+	124, // 9: bess.pb.WildcardMatchCommandAddArg.valuesv:type_name -> bess.pb.FieldData
+	124, // 10: bess.pb.WildcardMatchCommandDeleteArg.values:type_name -> bess.pb.FieldData
+	124, // 11: bess.pb.WildcardMatchCommandDeleteArg.masks:type_name -> bess.pb.FieldData
+	109, // 12: bess.pb.ACLArg.rules:type_name -> bess.pb.ACLArg.Rule
+	110, // 13: bess.pb.BPFArg.filters:type_name -> bess.pb.BPFArg.Filter
+	125, // 14: bess.pb.ExactMatchArg.fields:type_name -> bess.pb.Field
+	124, // 15: bess.pb.ExactMatchArg.masks:type_name -> bess.pb.FieldData
+	125, // 16: bess.pb.ExactMatchArg.values:type_name -> bess.pb.Field
+	124, // 17: bess.pb.ExactMatchArg.masksv:type_name -> bess.pb.FieldData
 	2,   // 18: bess.pb.ExactMatchConfig.rules:type_name -> bess.pb.ExactMatchCommandAddArg
-	106, // 19: bess.pb.GenericEncapArg.fields:type_name -> bess.pb.GenericEncapArg.EncapField
-	120, // 20: bess.pb.HashLBArg.fields:type_name -> bess.pb.Field
-	107, // 21: bess.pb.MetadataTestArg.read:type_name -> bess.pb.MetadataTestArg.ReadEntry
-	108, // 22: bess.pb.MetadataTestArg.write:type_name -> bess.pb.MetadataTestArg.WriteEntry
-	109, // 23: bess.pb.MetadataTestArg.update:type_name -> bess.pb.MetadataTestArg.UpdateEntry
-	111, // 24: bess.pb.NATArg.ext_addrs:type_name -> bess.pb.NATArg.ExternalAddress
-	113, // 25: bess.pb.StaticNATArg.pairs:type_name -> bess.pb.StaticNATArg.AddressRangePair
-	114, // 26: bess.pb.RandomUpdateArg.fields:type_name -> bess.pb.RandomUpdateArg.Field
-	115, // 27: bess.pb.SetMetadataArg.attrs:type_name -> bess.pb.SetMetadataArg.Attribute
-	116, // 28: bess.pb.UpdateArg.fields:type_name -> bess.pb.UpdateArg.Field
-	117, // 29: bess.pb.UrlFilterArg.blacklist:type_name -> bess.pb.UrlFilterArg.Url
-	117, // 30: bess.pb.UrlFilterConfig.blacklist:type_name -> bess.pb.UrlFilterArg.Url
-	120, // 31: bess.pb.WildcardMatchArg.fields:type_name -> bess.pb.Field
-	120, // 32: bess.pb.WildcardMatchArg.values:type_name -> bess.pb.Field
+	111, // 19: bess.pb.GenericEncapArg.fields:type_name -> bess.pb.GenericEncapArg.EncapField
+	125, // 20: bess.pb.HashLBArg.fields:type_name -> bess.pb.Field
+	112, // 21: bess.pb.MetadataTestArg.read:type_name -> bess.pb.MetadataTestArg.ReadEntry
+	113, // 22: bess.pb.MetadataTestArg.write:type_name -> bess.pb.MetadataTestArg.WriteEntry
+	114, // 23: bess.pb.MetadataTestArg.update:type_name -> bess.pb.MetadataTestArg.UpdateEntry
+	116, // 24: bess.pb.NATArg.ext_addrs:type_name -> bess.pb.NATArg.ExternalAddress
+	118, // 25: bess.pb.StaticNATArg.pairs:type_name -> bess.pb.StaticNATArg.AddressRangePair
+	119, // 26: bess.pb.RandomUpdateArg.fields:type_name -> bess.pb.RandomUpdateArg.Field
+	120, // 27: bess.pb.SetMetadataArg.attrs:type_name -> bess.pb.SetMetadataArg.Attribute
+	121, // 28: bess.pb.UpdateArg.fields:type_name -> bess.pb.UpdateArg.Field
+	122, // 29: bess.pb.UrlFilterArg.blacklist:type_name -> bess.pb.UrlFilterArg.Url
+	122, // 30: bess.pb.UrlFilterConfig.blacklist:type_name -> bess.pb.UrlFilterArg.Url
+	125, // 31: bess.pb.WildcardMatchArg.fields:type_name -> bess.pb.Field
+	125, // 32: bess.pb.WildcardMatchArg.values:type_name -> bess.pb.Field
 	32,  // 33: bess.pb.WildcardMatchConfig.rules:type_name -> bess.pb.WildcardMatchCommandAddArg
-	118, // 34: bess.pb.WorkerSplitArg.worker_gates:type_name -> bess.pb.WorkerSplitArg.WorkerGatesEntry
-	119, // 35: bess.pb.GenericEncapArg.EncapField.value:type_name -> bess.pb.FieldData
-	110, // 36: bess.pb.NATArg.ExternalAddress.port_ranges:type_name -> bess.pb.NATArg.PortRange
-	112, // 37: bess.pb.StaticNATArg.AddressRangePair.int_range:type_name -> bess.pb.StaticNATArg.AddressRange
-	112, // 38: bess.pb.StaticNATArg.AddressRangePair.ext_range:type_name -> bess.pb.StaticNATArg.AddressRange
-	39,  // [39:39] is the sub-list for method output_type
-	39,  // [39:39] is the sub-list for method input_type
-	39,  // [39:39] is the sub-list for extension type_name
-	39,  // [39:39] is the sub-list for extension extendee
-	0,   // [0:39] is the sub-list for field type_name
+	123, // 34: bess.pb.WorkerSplitArg.worker_gates:type_name -> bess.pb.WorkerSplitArg.WorkerGatesEntry
+	125, // 35: bess.pb.QosArg.fields:type_name -> bess.pb.Field
+	125, // 36: bess.pb.QosArg.values:type_name -> bess.pb.Field
+	124, // 37: bess.pb.QosCommandAddArg.fields:type_name -> bess.pb.FieldData
+	124, // 38: bess.pb.QosCommandAddArg.values:type_name -> bess.pb.FieldData
+	124, // 39: bess.pb.QosCommandDeleteArg.fields:type_name -> bess.pb.FieldData
+	124, // 40: bess.pb.GenericEncapArg.EncapField.value:type_name -> bess.pb.FieldData
+	115, // 41: bess.pb.NATArg.ExternalAddress.port_ranges:type_name -> bess.pb.NATArg.PortRange
+	117, // 42: bess.pb.StaticNATArg.AddressRangePair.int_range:type_name -> bess.pb.StaticNATArg.AddressRange
+	117, // 43: bess.pb.StaticNATArg.AddressRangePair.ext_range:type_name -> bess.pb.StaticNATArg.AddressRange
+	44,  // [44:44] is the sub-list for method output_type
+	44,  // [44:44] is the sub-list for method input_type
+	44,  // [44:44] is the sub-list for extension type_name
+	44,  // [44:44] is the sub-list for extension extendee
+	0,   // [0:44] is the sub-list for field type_name
 }
 
 func init() { file_module_msg_proto_init() }
@@ -8826,7 +9161,7 @@ func file_module_msg_proto_init() {
 			}
 		}
 		file_module_msg_proto_msgTypes[102].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*L2ForwardCommandAddArg_Entry); i {
+			switch v := v.(*QosArg); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -8838,7 +9173,7 @@ func file_module_msg_proto_init() {
 			}
 		}
 		file_module_msg_proto_msgTypes[103].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*MeasureCommandGetSummaryResponse_Histogram); i {
+			switch v := v.(*QosCommandAddArg); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -8850,7 +9185,7 @@ func file_module_msg_proto_init() {
 			}
 		}
 		file_module_msg_proto_msgTypes[104].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*ACLArg_Rule); i {
+			switch v := v.(*QosCommandDeleteArg); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -8862,7 +9197,7 @@ func file_module_msg_proto_init() {
 			}
 		}
 		file_module_msg_proto_msgTypes[105].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*BPFArg_Filter); i {
+			switch v := v.(*QosCommandClearArg); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -8874,7 +9209,43 @@ func file_module_msg_proto_init() {
 			}
 		}
 		file_module_msg_proto_msgTypes[106].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*GenericEncapArg_EncapField); i {
+			switch v := v.(*QosCommandSetDefaultGateArg); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_module_msg_proto_msgTypes[107].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*L2ForwardCommandAddArg_Entry); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_module_msg_proto_msgTypes[108].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*MeasureCommandGetSummaryResponse_Histogram); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_module_msg_proto_msgTypes[109].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*ACLArg_Rule); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -8886,7 +9257,7 @@ func file_module_msg_proto_init() {
 			}
 		}
 		file_module_msg_proto_msgTypes[110].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*NATArg_PortRange); i {
+			switch v := v.(*BPFArg_Filter); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -8898,43 +9269,7 @@ func file_module_msg_proto_init() {
 			}
 		}
 		file_module_msg_proto_msgTypes[111].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*NATArg_ExternalAddress); i {
-			case 0:
-				return &v.state
-			case 1:
-				return &v.sizeCache
-			case 2:
-				return &v.unknownFields
-			default:
-				return nil
-			}
-		}
-		file_module_msg_proto_msgTypes[112].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*StaticNATArg_AddressRange); i {
-			case 0:
-				return &v.state
-			case 1:
-				return &v.sizeCache
-			case 2:
-				return &v.unknownFields
-			default:
-				return nil
-			}
-		}
-		file_module_msg_proto_msgTypes[113].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*StaticNATArg_AddressRangePair); i {
-			case 0:
-				return &v.state
-			case 1:
-				return &v.sizeCache
-			case 2:
-				return &v.unknownFields
-			default:
-				return nil
-			}
-		}
-		file_module_msg_proto_msgTypes[114].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*RandomUpdateArg_Field); i {
+			switch v := v.(*GenericEncapArg_EncapField); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -8946,7 +9281,7 @@ func file_module_msg_proto_init() {
 			}
 		}
 		file_module_msg_proto_msgTypes[115].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*SetMetadataArg_Attribute); i {
+			switch v := v.(*NATArg_PortRange); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -8958,7 +9293,7 @@ func file_module_msg_proto_init() {
 			}
 		}
 		file_module_msg_proto_msgTypes[116].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*UpdateArg_Field); i {
+			switch v := v.(*NATArg_ExternalAddress); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -8970,6 +9305,66 @@ func file_module_msg_proto_init() {
 			}
 		}
 		file_module_msg_proto_msgTypes[117].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*StaticNATArg_AddressRange); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_module_msg_proto_msgTypes[118].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*StaticNATArg_AddressRangePair); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_module_msg_proto_msgTypes[119].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*RandomUpdateArg_Field); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_module_msg_proto_msgTypes[120].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*SetMetadataArg_Attribute); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_module_msg_proto_msgTypes[121].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*UpdateArg_Field); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_module_msg_proto_msgTypes[122].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*UrlFilterArg_Url); i {
 			case 0:
 				return &v.state
@@ -8994,11 +9389,11 @@ func file_module_msg_proto_init() {
 		(*TimestampArg_Offset)(nil),
 		(*TimestampArg_AttrName)(nil),
 	}
-	file_module_msg_proto_msgTypes[106].OneofWrappers = []interface{}{
+	file_module_msg_proto_msgTypes[111].OneofWrappers = []interface{}{
 		(*GenericEncapArg_EncapField_Attribute)(nil),
 		(*GenericEncapArg_EncapField_Value)(nil),
 	}
-	file_module_msg_proto_msgTypes[115].OneofWrappers = []interface{}{
+	file_module_msg_proto_msgTypes[120].OneofWrappers = []interface{}{
 		(*SetMetadataArg_Attribute_ValueInt)(nil),
 		(*SetMetadataArg_Attribute_ValueBin)(nil),
 	}
@@ -9008,7 +9403,7 @@ func file_module_msg_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_module_msg_proto_rawDesc,
 			NumEnums:      0,
-			NumMessages:   119,
+			NumMessages:   124,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/pfcpiface/main.go
+++ b/pfcpiface/main.go
@@ -25,21 +25,31 @@ var (
 
 // Conf : Json conf struct.
 type Conf struct {
-	Mode              string      `json:"mode"`
-	MaxSessions       uint32      `json:"max_sessions"`
-	AccessIface       IfaceType   `json:"access"`
-	CoreIface         IfaceType   `json:"core"`
-	CPIface           CPIfaceInfo `json:"cpiface"`
-	P4rtcIface        P4rtcInfo   `json:"p4rtciface"`
-	EnableP4rt        bool        `json:"enable_p4rt"`
-	SimInfo           SimModeInfo `json:"sim"`
-	ConnTimeout       uint32      `json:"conn_timeout"`
-	ReadTimeout       uint32      `json:"read_timeout"`
-	EnableNotifyBess  bool        `json:"enable_notify_bess"`
-	EnableEndMarker   bool        `json:"enable_end_marker"`
-	NotifySockAddr    string      `json:"notify_sockaddr"`
-	EndMarkerSockAddr string      `json:"endmarker_sockaddr"`
-	LogLevel          string      `json:"log_level"`
+	Mode              string         `json:"mode"`
+	MaxSessions       uint32         `json:"max_sessions"`
+	AccessIface       IfaceType      `json:"access"`
+	CoreIface         IfaceType      `json:"core"`
+	CPIface           CPIfaceInfo    `json:"cpiface"`
+	P4rtcIface        P4rtcInfo      `json:"p4rtciface"`
+	EnableP4rt        bool           `json:"enable_p4rt"`
+	SimInfo           SimModeInfo    `json:"sim"`
+	ConnTimeout       uint32         `json:"conn_timeout"`
+	ReadTimeout       uint32         `json:"read_timeout"`
+	EnableNotifyBess  bool           `json:"enable_notify_bess"`
+	EnableEndMarker   bool           `json:"enable_end_marker"`
+	NotifySockAddr    string         `json:"notify_sockaddr"`
+	EndMarkerSockAddr string         `json:"endmarker_sockaddr"`
+	LogLevel          string         `json:"log_level"`
+	QciQosConfig      []QciQosConfig `json:"qci_qos_config"`
+}
+
+// QciQosConfig : Qos configured attributes.
+type QciQosConfig struct {
+	QCI                uint8  `json:"qci"`
+	CBS                uint32 `json:"cbs"`
+	PBS                uint32 `json:"pbs"`
+	EBS                uint32 `json:"ebs"`
+	SchedulingPriority uint32 `json:"priority"`
 }
 
 // SimModeInfo : Sim mode attributes.

--- a/pfcpiface/upf.go
+++ b/pfcpiface/upf.go
@@ -10,6 +10,14 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// QosConfigVal : Qos configured value.
+type QosConfigVal struct {
+	cbs              uint32
+	pbs              uint32
+	ebs              uint32
+	schedulePriority uint32
+}
+
 type upf struct {
 	enableUeIPAlloc  bool
 	enableEndMarker  bool

--- a/pfcpiface/utils.go
+++ b/pfcpiface/utils.go
@@ -111,3 +111,11 @@ func getLocalIP(dstIP string) net.IP {
 
 	return localAddr.IP
 }
+
+func maxUint64(x, y uint64) uint64 {
+	if x < y {
+		return y
+	}
+
+	return x
+}


### PR DESCRIPTION
QoS: Add support for metering

This commit adds QoS module which can be thought of as an ExactMatch
module, with metering action using DPDK metering library. Arguments
to program the metering in the module - cir, pir, cbs, pbs and ebs are
exactly same as defined in the DPDK library.

This module has 4 reserved ogates - 
0 - METER - To indicate to modules that traffic matching entry with this
            gate need to be metered. Based on the result they will be
            sent out of one of the following gates
1 - GREEN - For traffic conformant to CIR
2 - YELLOW - For traffic conformant to PIR
3 - RED   - For traffic exceeding PIR

Apart from these there 3 more user-defined gates in up4.bess - 
4 - Default gate for lookup failures
5 - Explicitly asked to drop, modelling "Gate Status" closed
6 - Unmetered traffic, modelling PDRs without QER ID

metering.bess unit-test is provided to represent the UPF usage.

PFCP agent creates 2 entries for every incoming QER entry, as it consists
of UL and DL but the module is agnostic to the direction. GBR maps to CIR
and MBR maps to PIR.

Fixes: #299

Co-authored-by: Badhrinath Padmanabhan <badhrinath@opennetworking.org>
Co-authored-by: Amar Srivastava <amar.srivastava@intel.com>
Co-authored-by: Saikrishna Edupuganti <saikrishna.edupuganti@intel.com>