### PR TITLE
Delete all untagged images

### DIFF
--- a/.github/workflows/delete-untagged.yml
+++ b/.github/workflows/delete-untagged.yml
@@ -1,0 +1,23 @@
+name: Delete untagged images
+
+on:
+  schedule:
+    - cron: '0 0 * * SUN'
+  workflow_dispatch:
+jobs:
+  purge-image:
+    name: Delete image from ghcr.io
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        package: ["bess_build", "upf-epc-bess", "upf-epc-pfcpiface"]
+    steps:
+      - name: Delete image
+        uses: bots-house/ghcr-delete-image-action@9dee3adb4e4082ef06710f3d8aa9f7e73f89d189
+        with:
+          # NOTE: at now only orgs is supported
+          owner: omec-project
+          name: upf-epc/${{ matrix.package }}
+          # NOTE: using Personal Access Token
+          token: ${{ secrets.CR_PAT }}
+          untagged-keep-latest: 1


### PR DESCRIPTION
This will run as a cron job to delete untagged images from ghcr.
The action version is pinned currently to the SHA, until upstream tags
it with commit that introduced the feature to delete untagged images.