### PR TITLE
apn fqdn encode fix

### DIFF
--- a/pfcpiface/messages.go
+++ b/pfcpiface/messages.go
@@ -73,6 +73,7 @@ func (pc *PFCPConn) handleAssociationSetupRequest(upf *upf, msg message.Message,
 	// Timestamp shouldn't be the time message is sent in the real deployment but anyway :D
 	log.Println("Dnn info : ", upf.dnn)
 
+	networkInstance := string(ie.NewNetworkInstanceFQDN(upf.dnn).Payload)
 	flags := uint8(0x41)
 
 	if len(upf.dnn) != 0 {
@@ -86,7 +87,7 @@ func (pc *PFCPConn) handleAssociationSetupRequest(upf *upf, msg message.Message,
 		ie.NewCause(cause),                        /* accept it blindly for the time being */
 		// 0x41 = Spare (0) | Assoc Src Inst (1) | Assoc Net Inst (0) | Tied Range (000) | IPV6 (0) | IPV4 (1)
 		//      = 01000001
-		ie.NewUserPlaneIPResourceInformation(flags, 0, upf.accessIP.String(), "", upf.dnn, ie.SrcInterfaceAccess),
+		ie.NewUserPlaneIPResourceInformation(flags, 0, upf.accessIP.String(), "", networkInstance, ie.SrcInterfaceAccess),
 		// ie.NewUserPlaneIPResourceInformation(0x41, 0, coreIP, "", "", ie.SrcInterfaceCore),
 	) /* userplane ip resource info */
 

--- a/pfcpiface/p4rtc.go
+++ b/pfcpiface/p4rtc.go
@@ -29,9 +29,11 @@ const invalidID = 0
 
 // Table Entry Function Type.
 const (
-	FunctionTypeInsert uint8 = 1 // Insert table Entry Function
-	FunctionTypeUpdate uint8 = 2 // Update table Entry Function
-	FunctionTypeDelete uint8 = 3 // Delete table Entry Function
+	FunctionTypeInsert uint8  = 1               // Insert table Entry Function
+	FunctionTypeUpdate uint8  = 2               // Update table Entry Function
+	FunctionTypeDelete uint8  = 3               // Delete table Entry Function
+	SrcIfaceStr        string = "src_iface"     // Src Interface field name
+	InterfaceTypeStr   string = "InterfaceType" // Interface Type field name"
 )
 
 // IntfTableEntry ... Interface Table Entry API.
@@ -341,8 +343,8 @@ func (c *P4rtClient) WritePdrTable(pdrEntry pdr, funcType uint8) error {
 	te.FieldSize = 4
 	te.Fields = make([]MatchField, te.FieldSize)
 	te.FieldSize = 2
-	te.Fields[0].Name = "src_iface"
-	enumName := "InterfaceType"
+	te.Fields[0].Name = SrcIfaceStr
+	enumName := InterfaceTypeStr
 
 	var (
 		srcIntfStr string
@@ -442,8 +444,8 @@ func (c *P4rtClient) WriteInterfaceTable(intfEntry IntfTableEntry, funcType uint
 
 	te.ParamSize = 2
 	te.Params = make([]ActionParam, 2)
-	te.Params[0].Name = "src_iface"
-	enumName := "InterfaceType"
+	te.Params[0].Name = SrcIfaceStr
+	enumName := InterfaceTypeStr
 
 	val, err := c.getEnumVal(enumName, intfEntry.SrcIntf)
 	if err != nil {
@@ -831,8 +833,8 @@ func (c *P4rtClient) ReadInterfaceTable(intfEntry *IntfTableEntry) error {
 
 	te.ParamSize = 2
 	te.Params = make([]ActionParam, 2)
-	te.Params[0].Name = "src_iface"
-	enumName := "InterfaceType"
+	te.Params[0].Name = SrcIfaceStr
+	enumName := InterfaceTypeStr
 
 	val, err := c.getEnumVal(enumName, intfEntry.SrcIntf)
 	if err != nil {

--- a/pfcpiface/parse-qer.go
+++ b/pfcpiface/parse-qer.go
@@ -88,10 +88,10 @@ func (q *qer) parseQER(ie1 *ie.IE, seid uint64, upf *upf) error {
 	q.qfi = qfi
 	q.ulStatus = gsUL
 	q.dlStatus = gsDL
-	q.ulMbr = uint64(mbrUL)
-	q.dlMbr = uint64(mbrDL)
-	q.ulGbr = uint64(gbrUL)
-	q.dlGbr = uint64(gbrDL)
+	q.ulMbr = mbrUL
+	q.dlMbr = mbrDL
+	q.ulGbr = gbrUL
+	q.dlGbr = gbrDL
 	q.fseID = seid
 
 	return nil


### PR DESCRIPTION
In PFCP versions before 16.3 we send User Plane IP Resource Information in association setup response.
This contains the network instance (DNN) parameter which should be encoded as FQDN. But it is encoded as string. 
This can be fixed in the go-pfcp library also. But since the whole User Plane IP Resource Information parameter itself is deprecated, we are doing this change in pfcp agent. This will be updated when we start supporting release 16 and above in 5gc and upf.