### PR TITLE
Recalculate IP checksum so we do not drop it later

### DIFF
--- a/core/modules/ip_defrag.cc
+++ b/core/modules/ip_defrag.cc
@@ -10,6 +10,8 @@
 #include "utils/endian.h"
 /* for ToIpv4Address() */
 #include "utils/ip.h"
+/* for CalculateIpv4Checksum() */
+#include "utils/checksum.h"
 /* for eth header */
 #include "utils/ether.h"
 /*----------------------------------------------------------------------------------*/
@@ -65,12 +67,10 @@ bess::Packet *IPDefrag::IPReassemble(Context *ctx, bess::Packet *p) {
       }
     }
   }
-  /*
-   * Reset checksum. This will be computed by a later module in line (if needed)
-   * COMMENTING THIS OUT AS IP CHECKSUM IS NOT COMPUTED OTHERWISE DOWN THE
-   * PIPELINE
-   */
-  // iph->checksum = 0;
+
+  // Recalculate checksum
+  iph->checksum = 0;
+  iph->checksum = CalculateIpv4Checksum(*iph);
 
   return p;
 }


### PR DESCRIPTION
When we have reassembled all the fragments and are ready to return it,
lets recalculate the IP checksum. Currently, due to incorrect checksum
we end up dropping in the later stage of the pipeline.

Signed-off-by: Saikrishna Edupuganti <saikrishna.edupuganti@intel.com>