### PR TITLE
Add timestamp to pfcpPI interface

### DIFF
--- a/conf/up4.bess
+++ b/conf/up4.bess
@@ -252,7 +252,7 @@ farLookup:GTPUEncap \
 
 notify = UnixSocketPort(name='notifyCP', path=parser.notify_sockaddr)
 pfcpPort = UnixSocketPort(name='pfcpPort', path=parser.endmarker_sockaddr)
-pfcpPI::PortInc(port='pfcpPort') -> ports[parser.access_ifname].rtr
+pfcpPI::PortInc(port='pfcpPort') -> pfcpPI_timestamp::Timestamp() -> ports[parser.access_ifname].rtr
 executeFAR:farNotifyCPAction -> pfcpDetails::GenericEncap(fields=[ {'size': 8, 'attribute': 'fseid'}]) \
                              -> farNotifyCP::PortOut(port='notifyCP')
 # Drop unknown packets


### PR DESCRIPTION
We are adding this purely to trigger the offset computation for `timestamp` metadata. https://github.com/omec-project/upf-epc/issues/336#issuecomment-930240964

Discovered the issue by running this [test case](https://github.com/NetSys/bess/blob/master/bessctl/conf/metadata/test_corner.bess)
```
I0929 15:41:08.477003 89456 resume_hook.cc:70] Running global resume hook 'setup_metadata'
I0929 15:41:08.477036 89456 metadata.cc:402] scope component for 2-byte attr foo at offset -1: {
I0929 15:41:08.477046 89456 metadata.cc:407] a
I0929 15:41:08.477056 89456 metadata.cc:410] }
I0929 15:41:08.477066 89456 metadata.cc:402] scope component for 2-byte attr bar at offset -2: {
I0929 15:41:08.477077 89456 metadata.cc:407] b
I0929 15:41:08.477087 89456 metadata.cc:407] c
I0929 15:41:08.477097 89456 metadata.cc:407] a
I0929 15:41:08.477104 89456 metadata.cc:410] }
I0929 15:41:08.477113 89456 metadata.cc:421] Module a part of the following scope components: 
I0929 15:41:08.477124 89456 metadata.cc:421] Module b part of the following scope components: 
I0929 15:41:08.477135 89456 metadata.cc:421] Module c part of the following scope components: 
W0929 15:41:08.477145 89456 metadata.cc:77] Metadata attr bar/2 of module c has no upstream module that sets the value!
```

```
$ curl -s -q 172.17.0.2:8080/metrics 2>&1 | grep upf
# HELP upf_jitter_ns Shows the packet processing jitter percentiles in UPF
# TYPE upf_jitter_ns summary
upf_jitter_ns{iface="Access",quantile="50"} 0
upf_jitter_ns{iface="Access",quantile="75"} 0
upf_jitter_ns{iface="Access",quantile="90"} 100
upf_jitter_ns{iface="Access",quantile="95"} 100
upf_jitter_ns{iface="Access",quantile="99"} 3100
upf_jitter_ns{iface="Access",quantile="99.9"} 16000
upf_jitter_ns{iface="Access",quantile="99.99"} 17000
upf_jitter_ns{iface="Access",quantile="99.999"} 19200
upf_jitter_ns{iface="Access",quantile="99.9999"} 19500
upf_jitter_ns{iface="Access",quantile="100"} 19500
upf_jitter_ns_sum{iface="Access"} 6.25628e+07
upf_jitter_ns_count{iface="Access"} 9.848142e+06
upf_jitter_ns{iface="Core",quantile="50"} 0
upf_jitter_ns{iface="Core",quantile="75"} 0
upf_jitter_ns{iface="Core",quantile="90"} 100
upf_jitter_ns{iface="Core",quantile="95"} 100
upf_jitter_ns{iface="Core",quantile="99"} 2700
upf_jitter_ns{iface="Core",quantile="99.9"} 16000
upf_jitter_ns{iface="Core",quantile="99.99"} 18900
upf_jitter_ns{iface="Core",quantile="99.999"} 21000
upf_jitter_ns{iface="Core",quantile="99.9999"} 22000
upf_jitter_ns{iface="Core",quantile="100"} 22000
upf_jitter_ns_sum{iface="Core"} 7.03198e+07
upf_jitter_ns_count{iface="Core"} 1.12306e+07
# HELP upf_latency_ns Shows the packet processing latency percentiles in UPF
# TYPE upf_latency_ns summary
upf_latency_ns{iface="Access",quantile="50"} 14300
upf_latency_ns{iface="Access",quantile="75"} 14400
upf_latency_ns{iface="Access",quantile="90"} 15100
upf_latency_ns{iface="Access",quantile="95"} 15400
upf_latency_ns{iface="Access",quantile="99"} 17000
upf_latency_ns{iface="Access",quantile="99.9"} 31000
upf_latency_ns{iface="Access",quantile="99.99"} 31800
upf_latency_ns{iface="Access",quantile="99.999"} 34400
upf_latency_ns{iface="Access",quantile="99.9999"} 34400
upf_latency_ns{iface="Access",quantile="100"} 34400
upf_latency_ns_sum{iface="Access"} 1.434115379e+11
upf_latency_ns_count{iface="Access"} 9.848142e+06
upf_latency_ns{iface="Core",quantile="50"} 13400
upf_latency_ns{iface="Core",quantile="75"} 13500
upf_latency_ns{iface="Core",quantile="90"} 14100
upf_latency_ns{iface="Core",quantile="95"} 14400
upf_latency_ns{iface="Core",quantile="99"} 16400
upf_latency_ns{iface="Core",quantile="99.9"} 30100
upf_latency_ns{iface="Core",quantile="99.99"} 36600
upf_latency_ns{iface="Core",quantile="99.999"} 61700
upf_latency_ns{iface="Core",quantile="99.9999"} 70400
upf_latency_ns{iface="Core",quantile="100"} 70800
upf_latency_ns_sum{iface="Core"} 1.529525314e+11
upf_latency_ns_count{iface="Core"} 1.12306e+07
```

Fixes: #336