### PR TITLE
Use output format tar and then untar

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -126,4 +126,4 @@ COPY --from=go-pb /bess_pb /bess_pb
 FROM scratch AS artifacts
 COPY --from=bess /bin/bessd /
 COPY --from=pfcpiface /bin/pfcpiface /
-# COPY --from=bess-build /bess /
+COPY --from=bess-build /bess /bess

--- a/Makefile
+++ b/Makefile
@@ -53,16 +53,17 @@ docker-push:
 
 # Change target to bess-build/pfcpiface to exctract src/obj/bins for performance analysis
 output:
-	DOCKER_BUILDKIT=$(DOCKER_BUILDKIT) docker build $(DOCKER_BUILD_ARGS) \
+	DOCKER_BUILDKIT=$(DOCKER_BUILDKIT) docker build $(DOCKER_PULL) $(DOCKER_BUILD_ARGS) \
 		--target artifacts \
-		--output output \
+		--output type=tar,dest=output.tar \
 		.;
+	rm -rf output && mkdir output && tar -xf output.tar -C output && rm -f output.tar
 
 # Golang grpc/protobuf generation
 BESS_PB_DIR ?= pfcpiface
 
 pb:
-	DOCKER_BUILDKIT=$(DOCKER_BUILDKIT) docker build $(DOCKER_BUILD_ARGS) \
+	DOCKER_BUILDKIT=$(DOCKER_BUILDKIT) docker build $(DOCKER_PULL) $(DOCKER_BUILD_ARGS) \
 		--target pb \
 		--output output \
 		.;


### PR DESCRIPTION
Directly using output directory method would hang copying out the
artifacts. So instead use the tar method and untar.

Add DOCKER_PULL to other make targets to be consistent

Signed-off-by: Saikrishna Edupuganti <saikrishna.edupuganti@intel.com>