### PR TITLE
Cleanly allow IP address provided as node id

### DIFF
--- a/pfcpiface/messages-session.go
+++ b/pfcpiface/messages-session.go
@@ -62,11 +62,11 @@ func (pConn *PFCPConn) handleSessionEstablishmentRequest(msg message.Message) (m
 
 		// Build response message
 		seres := message.NewSessionEstablishmentResponse(0, /* MO?? <-- what's this */
-			0,                                        /* FO <-- what's this? */
-			remoteSEID,                               /* seid */
-			sereq.SequenceNumber,                     /* seq # */
-			0,                                        /* priority */
-			ie.NewNodeID(pConn.nodeID.local, "", ""), /* node id (IPv4) */
+			0,                    /* FO <-- what's this? */
+			remoteSEID,           /* seid */
+			sereq.SequenceNumber, /* seq # */
+			0,                    /* priority */
+			pConn.nodeID.localIE,
 			ie.NewCause(cause),
 		)
 
@@ -137,12 +137,12 @@ func (pConn *PFCPConn) handleSessionEstablishmentRequest(msg message.Message) (m
 
 	// Build response message
 	seres := message.NewSessionEstablishmentResponse(0, /* MO?? <-- what's this */
-		0,                                        /* FO <-- what's this? */
-		session.remoteSEID,                       /* seid */
-		sereq.SequenceNumber,                     /* seq # */
-		0,                                        /* priority */
-		ie.NewNodeID(pConn.nodeID.local, "", ""), /* node id (IPv4) */
-		ie.NewCause(ie.CauseRequestAccepted),     /* accept it blindly for the time being */
+		0,                                    /* FO <-- what's this? */
+		session.remoteSEID,                   /* seid */
+		sereq.SequenceNumber,                 /* seq # */
+		0,                                    /* priority */
+		pConn.nodeID.localIE,                 /* node id */
+		ie.NewCause(ie.CauseRequestAccepted), /* accept it blindly for the time being */
 		localFSEID,
 	)
 

--- a/pfcpiface/node.go
+++ b/pfcpiface/node.go
@@ -74,12 +74,7 @@ func (node *PFCPNode) handleNewPeers() {
 			continue
 		}
 
-		// TODO: Logic to distinguish PFCPConn based on SEID
-		p := node.NewPFCPConn(lAddrStr, rAddrStr)
-		node.pConns[rAddrStr] = p
-		p.HandlePFCPMsg(buf[:n])
-
-		go p.Serve()
+		node.NewPFCPConn(lAddrStr, rAddrStr, buf[:n])
 	}
 }
 


### PR DESCRIPTION
Remove the TODO of correctly figuring out if node_id passed is FQDN or IPv4 or IPv6
Once figured out cache the result in PFCPConn.nodeID

Signed-off-by: Saikrishna Edupuganti <saikrishna.edupuganti@intel.com>