### PR TITLE
Run simulation mode as part of pfcp agent

### DIFF
--- a/pfcpiface/grpcsim.go
+++ b/pfcpiface/grpcsim.go
@@ -4,11 +4,69 @@
 package main
 
 import (
+	"fmt"
 	"time"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/wmnsk/go-pfcp/ie"
 )
+
+// simMode : Type indicating the desired simulation mode.
+type simMode int
+
+const (
+	simModeDisable simMode = iota
+	simModeCreate
+	simModeDelete
+	simModeCreateAndContinue
+)
+
+func (s *simMode) String() string {
+	switch *s {
+	case simModeDisable:
+		return "disable"
+	case simModeCreate:
+		return "create"
+	case simModeDelete:
+		return "delete"
+	case simModeCreateAndContinue:
+		return "create_continue"
+	default:
+		return "unknown sim mode"
+	}
+}
+
+func (s *simMode) Set(value string) error {
+	switch value {
+	case "disable":
+		*s = simModeDisable
+	case "create":
+		*s = simModeCreate
+	case "delete":
+		*s = simModeDelete
+	case "create_continue":
+		*s = simModeCreateAndContinue
+	default:
+		return fmt.Errorf("unknown sim mode %v", value)
+	}
+	return nil
+}
+
+func (s simMode) create() bool {
+	return s == simModeCreate || s == simModeCreateAndContinue
+}
+
+func (s simMode) delete() bool {
+	return s == simModeDelete
+}
+
+func (s simMode) keepGoing() bool {
+	return s == simModeCreateAndContinue
+}
+
+func (s simMode) enable() bool {
+	return s != simModeDisable
+}
 
 func (u *upf) sim(mode simMode, s *SimModeInfo) {
 	log.Infoln(simulate.String(), "sessions:", s.MaxSessions)

--- a/pfcpiface/grpcsim.go
+++ b/pfcpiface/grpcsim.go
@@ -10,8 +10,8 @@ import (
 	"github.com/wmnsk/go-pfcp/ie"
 )
 
-func (u *upf) sim(method string, s *SimModeInfo) {
-	log.Infoln(*simulate, "sessions:", s.MaxSessions)
+func (u *upf) sim(mode simMode, s *SimModeInfo) {
+	log.Infoln(simulate.String(), "sessions:", s.MaxSessions)
 
 	start := time.Now()
 	ueip := s.StartUEIP
@@ -189,15 +189,12 @@ func (u *upf) sim(method string, s *SimModeInfo) {
 
 		qers = append(qers, sessionQer)
 
-		switch method {
-		case "create":
+		if mode.create() {
 			u.sendMsgToUPF(upfMsgTypeAdd, pdrs, fars, qers)
-
-		case "delete":
+		} else if mode.delete() {
 			u.sendMsgToUPF(upfMsgTypeDel, pdrs, fars, qers)
-
-		default:
-			log.Fatalln("Unsupported method", method)
+		} else {
+			log.Fatalln("Unsupported method", mode)
 		}
 	}
 

--- a/pfcpiface/main.go
+++ b/pfcpiface/main.go
@@ -7,21 +7,23 @@ import (
 	"context"
 	"encoding/json"
 	"flag"
+	"fmt"
 	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 
 	log "github.com/sirupsen/logrus"
 )
 
 var (
-	configPath = flag.String("config", "upf.json", "path to upf config")
-	httpAddr   = flag.String("http", "0.0.0.0:8080", "http IP/port combo")
-	simulate   = flag.String("simulate", "", "create|delete simulated sessions")
-	pfcpsim    = flag.Bool("pfcpsim", false, "simulate PFCP")
+	configPath         = flag.String("config", "upf.json", "path to upf config")
+	httpAddr           = flag.String("http", "0.0.0.0:8080", "http IP/port combo")
+	pfcpsim            = flag.Bool("pfcpsim", false, "simulate PFCP")
+	simulate   simMode = ""
 )
 
 // Conf : Json conf struct.
@@ -90,6 +92,43 @@ type IfaceType struct {
 	IfName string `json:"ifname"`
 }
 
+// simMode : Type indicating the desired simulation mode.
+type simMode string
+
+func (s *simMode) String() string {
+	return string(*s)
+}
+
+func (s *simMode) Set(value string) error {
+	switch value {
+	case "create":
+		fallthrough
+	case "create_continue":
+		fallthrough
+	case "delete":
+		*s = simMode(value)
+	default:
+		return fmt.Errorf("unknown sim mode %v", value)
+	}
+	return nil
+}
+
+func (s *simMode) create() bool {
+	return strings.Contains(string(*s), "create")
+}
+
+func (s *simMode) delete() bool {
+	return strings.Contains(string(*s), "delete")
+}
+
+func (s *simMode) keepGoing() bool {
+	return strings.Contains(string(*s), "continue")
+}
+
+func (s *simMode) enable() bool {
+	return string(*s) != ""
+}
+
 // ParseJSON : parse json file and populate corresponding struct.
 func ParseJSON(filepath *string, conf *Conf) {
 	/* Open up file */
@@ -151,6 +190,7 @@ func ParseIP(name string, iface string) net.IP {
 }
 
 func init() {
+	flag.Var(&simulate, "simulate", "create|delete|create_continue simulated sessions")
 	// Set up logger
 	log.SetReportCaller(true)
 	log.SetFormatter(&log.TextFormatter{
@@ -191,14 +231,11 @@ func main() {
 		return
 	}
 
-	if *simulate != "" {
-		if *simulate != "create" && *simulate != "delete" {
-			log.Fatalln("Invalid simulate method", simulate)
+	if simulate.enable() {
+		upf.sim(simulate, &conf.SimInfo)
+		if !simulate.keepGoing() {
+			return
 		}
-
-		upf.sim(*simulate, &conf.SimInfo)
-
-		return
 	}
 
 	setupConfigHandler(upf)

--- a/pfcpiface/main.go
+++ b/pfcpiface/main.go
@@ -7,23 +7,21 @@ import (
 	"context"
 	"encoding/json"
 	"flag"
-	"fmt"
 	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
 	"os/signal"
-	"strings"
 	"syscall"
 
 	log "github.com/sirupsen/logrus"
 )
 
 var (
-	configPath         = flag.String("config", "upf.json", "path to upf config")
-	httpAddr           = flag.String("http", "0.0.0.0:8080", "http IP/port combo")
-	pfcpsim            = flag.Bool("pfcpsim", false, "simulate PFCP")
-	simulate   simMode = ""
+	configPath = flag.String("config", "upf.json", "path to upf config")
+	httpAddr   = flag.String("http", "0.0.0.0:8080", "http IP/port combo")
+	simulate   = simModeDisable
+	pfcpsim    = flag.Bool("pfcpsim", false, "simulate PFCP")
 )
 
 // Conf : Json conf struct.
@@ -90,43 +88,6 @@ type CPIfaceInfo struct {
 // IfaceType : Gateway interface struct.
 type IfaceType struct {
 	IfName string `json:"ifname"`
-}
-
-// simMode : Type indicating the desired simulation mode.
-type simMode string
-
-func (s *simMode) String() string {
-	return string(*s)
-}
-
-func (s *simMode) Set(value string) error {
-	switch value {
-	case "create":
-		fallthrough
-	case "create_continue":
-		fallthrough
-	case "delete":
-		*s = simMode(value)
-	default:
-		return fmt.Errorf("unknown sim mode %v", value)
-	}
-	return nil
-}
-
-func (s *simMode) create() bool {
-	return strings.Contains(string(*s), "create")
-}
-
-func (s *simMode) delete() bool {
-	return strings.Contains(string(*s), "delete")
-}
-
-func (s *simMode) keepGoing() bool {
-	return strings.Contains(string(*s), "continue")
-}
-
-func (s *simMode) enable() bool {
-	return string(*s) != ""
 }
 
 // ParseJSON : parse json file and populate corresponding struct.


### PR DESCRIPTION
Right now we have the spin up another pfcp agent instance to simulate session creation (`-simulate create`) or deletion. As this runs in a completely separate process from the persistent agent, they do not share any state. This is problematic when other features, like flow measure, require data from inserted PDRs. 
Realistically, production setups should not be affected as all programming happens through PFCP messages, but for local testing this is a huge shortcoming. Especially since there is no equivalent simulator on the PFCP level available.

This change adds a new `-simulate` flag value, `create_continue`, which runs the sim function as part of the agent startup procedure.