### PR TITLE
Fix: gtpu echo priority should be greater than pdu

### DIFF
--- a/conf/up4.bess
+++ b/conf/up4.bess
@@ -436,7 +436,7 @@ check_gtpu_port = " and udp dst port 2152"
 check_gtpu_msg_echo = " and udp[9] = 0x1"
 
 # Echo filter
-uplink_echo_filter = {"priority": -GTPUEchoGate, "filter": check_ip +
+uplink_echo_filter = {"priority": GTPUEchoGate, "filter": check_ip +
                       check_spgwu_ip + check_gtpu_port +
                       check_gtpu_msg_echo, "gate": GTPUEchoGate}
 accessFastBPF.add(filters=[uplink_echo_filter])


### PR DESCRIPTION
In the Access BPF, the gtpu echo filter should be of higher priority
than gtpu pdu. It is still unclear how it working previously.
https://github.com/omec-project/upf-epc/compare/08a12f9...9a3fc9a

Fixes: #364