### PR TITLE
Fix `FlowMeasure` read response when no traffic is flowing

### DIFF
--- a/core/modules/flow_measure.cc
+++ b/core/modules/flow_measure.cc
@@ -187,6 +187,8 @@ CommandResponse FlowMeasure::CommandReadStats(
   rte_hash *current_hash = nullptr;
   std::vector<SessionStats> *current_data = nullptr;
   switch (cached_current_flag) {  // Pick the offline buffer set.
+    case Flag::FLAG_VALUE_INVALID:
+      return CommandSuccess(resp);  // return empty stats when no traffic
     case Flag::FLAG_VALUE_A:
       current_hash = table_b_;
       current_data = &table_data_b_;

--- a/pfcpiface/bess.go
+++ b/pfcpiface/bess.go
@@ -355,7 +355,7 @@ func (b *bess) readFlowMeasurement(
 		return
 	}
 	if resp.GetError() != nil {
-		log.Errorln(module, "error reading flow stats:", res.GetError().Errmsg)
+		log.Errorln(module, "error reading flow stats:", resp.GetError().Errmsg)
 		return
 	}
 	if err = resp.Data.UnmarshalTo(&stats); err != nil {

--- a/pfcpiface/bess.go
+++ b/pfcpiface/bess.go
@@ -354,6 +354,10 @@ func (b *bess) readFlowMeasurement(
 		log.Errorln(module, "read failed!:", err)
 		return
 	}
+	if resp.GetError() != nil {
+		log.Errorln(module, "error reading flow stats:", res.GetError().Errmsg)
+		return
+	}
 	if err = resp.Data.UnmarshalTo(&stats); err != nil {
 		log.Errorln(err)
 		return


### PR DESCRIPTION
We discovered that reading a follower flow measurement module when there as been no traffic results in an error, as no flag value has been seen by the module. This fixes the error by returning an empty response. 