### PR TITLE
Allocate UE IPs based on `SEID`

### DIFF
--- a/pfcpiface/ip_pool.go
+++ b/pfcpiface/ip_pool.go
@@ -5,7 +5,9 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"net"
+	"strings"
 	"sync"
 
 	log "github.com/sirupsen/logrus"
@@ -14,31 +16,27 @@ import (
 type IPPool struct {
 	mu       sync.Mutex
 	freePool []net.IP
-	// inventory makes note if IP is allocated
-	inventory map[string]bool
+	// inventory keeps track of allocated sessions and their IPs
+	inventory map[uint64]net.IP
 }
 
-func (i *IPPool) DeallocIP(ip net.IP) {
+func (i *IPPool) DeallocIP(seid uint64) error {
 	i.mu.Lock()
 	defer i.mu.Unlock()
 
-	isAllocated, ok := i.inventory[ip.String()]
+	ip, ok := i.inventory[seid]
 	if !ok {
-		log.Warnln("Attempt to dealloc non-existent IP", ip)
-		return
+		log.Warnln("Attempt to dealloc non-existent session", seid)
+		return fmt.Errorf("can't dealloc non-existent session %v", seid)
 	}
 
-	if !isAllocated {
-		log.Warnln("Attempt to dealloc a free IP", ip)
-		return
-	}
-
-	i.inventory[ip.String()] = false
+	delete(i.inventory, seid)
 	i.freePool = append(i.freePool, ip) // Simply append to enqueue.
-	log.Traceln("Deallocated IP:", ip)
+	log.Traceln("Deallocated session ", seid, "IP", ip)
+	return nil
 }
 
-func (i *IPPool) AllocIP() (net.IP, error) {
+func (i *IPPool) LookupOrAllocIP(seid uint64) (net.IP, error) {
 	i.mu.Lock()
 	defer i.mu.Unlock()
 
@@ -47,12 +45,39 @@ func (i *IPPool) AllocIP() (net.IP, error) {
 		return nil, err
 	}
 
-	ip := i.freePool[0]
-	i.inventory[ip.String()] = true
-	i.freePool = i.freePool[1:] // Slice off the element once it is dequeued.
+	// Try to find an exiting session and return the allocated IP.
+	ip, found := i.inventory[seid]
+	if found {
+		log.Traceln("Found existing session", seid, "IP", ip)
+		return ip, nil
+	}
 
-	log.Traceln("Allocated IP:", ip)
-	return ip, nil
+	ip = i.freePool[0]
+	i.freePool = i.freePool[1:] // Slice off the element once it is dequeued.
+	i.inventory[seid] = ip
+	log.Traceln("Allocated new session", seid, "IP", ip)
+
+	ipVal := make(net.IP, len(ip))
+	copy(ipVal, ip)
+
+	return ipVal, nil
+}
+
+func (i *IPPool) String() string {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	sb := strings.Builder{}
+	sb.WriteString("Inventory:\n")
+	for s, e := range i.inventory {
+		sb.WriteString(fmt.Sprintf("\tSEID %v -> %+v\n", s, e))
+	}
+
+	sb.WriteString("Free Pool:\n")
+	for _, ip := range i.freePool {
+		sb.WriteString(fmt.Sprintf("\tIP %s\n", ip.String()))
+	}
+
+	return sb.String()
 }
 
 func NewIPPool(cidr string) (*IPPool, error) {
@@ -62,13 +87,12 @@ func NewIPPool(cidr string) (*IPPool, error) {
 	}
 
 	i := &IPPool{
-		inventory: make(map[string]bool),
+		inventory: make(map[uint64]net.IP),
 	}
 
 	for ip := ip.Mask(ipnet.Mask); ipnet.Contains(ip); inc(ip) {
 		ipVal := make(net.IP, len(ip))
 		copy(ipVal, ip)
-		i.inventory[ipVal.String()] = false
 		i.freePool = append(i.freePool, ipVal)
 	}
 

--- a/pfcpiface/messages-session.go
+++ b/pfcpiface/messages-session.go
@@ -414,7 +414,7 @@ func (pConn *PFCPConn) handleSessionDeletionRequest(msg message.Message) (messag
 		return sendError(errors.New("write to FastPath failed"))
 	}
 
-	if err := upf.ippool.DeallocIP(session.localSEID); err != nil {
+	if err := releaseAllocatedIPs(upf.ippool, session); err != nil {
 		return sendError(errors.New("session IP dealloc failed"))
 	}
 

--- a/pfcpiface/messages-session.go
+++ b/pfcpiface/messages-session.go
@@ -414,7 +414,10 @@ func (pConn *PFCPConn) handleSessionDeletionRequest(msg message.Message) (messag
 		return sendError(errors.New("write to FastPath failed"))
 	}
 
-	releaseAllocatedIPs(upf.ippool, session)
+	if err := upf.ippool.DeallocIP(session.localSEID); err != nil {
+		return sendError(errors.New("session IP dealloc failed"))
+	}
+
 	/* delete sessionRecord */
 	pConn.RemoveSession(localSEID)
 

--- a/pfcpiface/parse-pdr.go
+++ b/pfcpiface/parse-pdr.go
@@ -87,7 +87,7 @@ func (p pdr) String() string {
 	return b.String()
 }
 
-func (p *pdr) parsePDI(pdiIEs []*ie.IE, appPFDs map[string]appPFD, ippool *IPPool) error {
+func (p *pdr) parsePDI(seid uint64, pdiIEs []*ie.IE, appPFDs map[string]appPFD, ippool *IPPool) error {
 	var ueIP4 net.IP
 
 	for _, pdiIE := range pdiIEs {
@@ -95,17 +95,16 @@ func (p *pdr) parsePDI(pdiIEs []*ie.IE, appPFDs map[string]appPFD, ippool *IPPoo
 		case ie.UEIPAddress:
 			ueIPaddr, err := pdiIE.UEIPAddress()
 			if err != nil {
-				log.Println("Failed to parse UE IP address")
+				log.Warnln("Failed to parse UE IP address")
 				continue
 			}
 
 			if needAllocIP(ueIPaddr) {
 				/* alloc IPV6 if CHV6 is enabled : TBD */
-				log.Println("UPF should alloc UE IP. CHV4 flag set")
-
-				ueIP4, err = ippool.AllocIP()
+				log.Printf("UPF should alloc UE IP for SEID %v. CHV4 flag set", seid)
+				ueIP4, err = ippool.LookupOrAllocIP(seid)
 				if err != nil {
-					log.Println("failed to allocate UE IP")
+					log.Errorln("failed to allocate UE IP")
 					return err
 				}
 
@@ -287,7 +286,7 @@ func (p *pdr) parsePDR(ie1 *ie.IE, seid uint64, appPFDs map[string]appPFD, ippoo
 		outerHeaderRemoval = 1
 	}
 
-	err = p.parsePDI(pdi, appPFDs, ippool)
+	err = p.parsePDI(seid, pdi, appPFDs, ippool)
 	if err != nil && !errors.Is(err, errBadFilterDesc) {
 		return err
 	}

--- a/pfcpiface/parse-pdr.go
+++ b/pfcpiface/parse-pdr.go
@@ -103,12 +103,11 @@ func (p *pdr) parsePDI(seid uint64, pdiIEs []*ie.IE, appPFDs map[string]appPFD, 
 				/* alloc IPV6 if CHV6 is enabled : TBD */
 				log.Printf("UPF should alloc UE IP for SEID %v. CHV4 flag set", seid)
 				ueIP4, err = ippool.LookupOrAllocIP(seid)
+				log.Traceln("Found or allocated new IP", ueIP4, "from pool", ippool)
 				if err != nil {
 					log.Errorln("failed to allocate UE IP")
 					return err
 				}
-
-				log.Println("ueipv4 : ", ueIP4.String())
 
 				p.allocIPFlag = true
 			} else {

--- a/pfcpiface/session-pdr.go
+++ b/pfcpiface/session-pdr.go
@@ -12,6 +12,21 @@ import (
 	"github.com/wmnsk/go-pfcp/message"
 )
 
+// Release allocated IPs.
+func releaseAllocatedIPs(ippool *IPPool, session *PFCPSession) error {
+	log.Println("release allocated IP")
+
+	// Check if we allocated an UE IP for this session and delete it.
+	for _, pdr := range session.pdrs {
+		if (pdr.allocIPFlag) && (pdr.srcIface == core) {
+			var ueIP net.IP = int2ip(pdr.dstIP)
+			log.Traceln("Releasing IP", ueIP, " of session", session.localSEID)
+			return ippool.DeallocIP(session.localSEID)
+		}
+	}
+	return nil
+}
+
 func addPdrInfo(msg *message.SessionEstablishmentResponse,
 	session *PFCPSession) {
 	log.Println("Add PDRs with UPF alloc IPs to Establishment response")

--- a/pfcpiface/session-pdr.go
+++ b/pfcpiface/session-pdr.go
@@ -12,21 +12,6 @@ import (
 	"github.com/wmnsk/go-pfcp/message"
 )
 
-// Release allocated IPs.
-func releaseAllocatedIPs(ippool *IPPool, session *PFCPSession) {
-	log.Println("release allocated IPs")
-
-	for _, pdr := range session.pdrs {
-		if (pdr.allocIPFlag) && (pdr.srcIface == core) {
-			var ueIP net.IP = int2ip(pdr.dstIP)
-
-			log.Println("pdrID : ", pdr.pdrID, ", ueIP : ", ueIP.String())
-
-			ippool.DeallocIP(ueIP)
-		}
-	}
-}
-
 func addPdrInfo(msg *message.SessionEstablishmentResponse,
 	session *PFCPSession) {
 	log.Println("Add PDRs with UPF alloc IPs to Establishment response")


### PR DESCRIPTION
We encountered a bug when using UE IP allocation and sending multiple PDRs for one session. The code allocated one UE IP per PDR, which leads to incorrect data plane programming and loss of connectivity for the UE.

This PR changes the IP allocation scheme from per-PDR to per-SEID. Only the first time we see a new session we allocate a new IP. Subsequent calls are satisfied with the same IP. On `SessionDeletion` we free the address.