### PR TITLE
Reject malformed QERs

### DIFF
--- a/pfcpiface/parse-qer.go
+++ b/pfcpiface/parse-qer.go
@@ -43,46 +43,70 @@ func (q qer) String() string {
 	return b.String()
 }
 
+func isValidGateStatus(gs uint8) bool {
+	switch gs {
+	case ie.GateStatusOpen:
+		fallthrough
+	case ie.GateStatusClosed:
+		return true
+	default:
+		return false
+	}
+}
+
 func (q *qer) parseQER(ie1 *ie.IE, seid uint64, upf *upf) error {
 	qerID, err := ie1.QERID()
 	if err != nil {
 		log.Println("Could not read QER ID!")
-		return nil
+		return err
 	}
 
 	qfi, err := ie1.QFI()
 	if err != nil {
 		log.Println("Could not read QFI!")
+		return err
 	}
 
 	gsUL, err := ie1.GateStatusUL()
 	if err != nil {
 		log.Println("Could not read Gate status uplink!")
+		return err
+	}
+	if !isValidGateStatus(gsUL) {
+		return fmt.Errorf("invalid uplink gate status %v", gsUL)
 	}
 
 	gsDL, err := ie1.GateStatusDL()
 	if err != nil {
 		log.Println("Could not read Gate status downlink!")
+		return err
+	}
+	if !isValidGateStatus(gsDL) {
+		return fmt.Errorf("invalid downlink gate status %v", gsDL)
 	}
 
 	mbrUL, err := ie1.MBRUL()
 	if err != nil {
 		log.Println("Could not read MBRUL!")
+		return err
 	}
 
 	mbrDL, err := ie1.MBRDL()
 	if err != nil {
 		log.Println("Could not read MBRDL!")
+		return err
 	}
 
 	gbrUL, err := ie1.GBRUL()
 	if err != nil {
 		log.Println("Could not read GBRUL!")
+		return err
 	}
 
 	gbrDL, err := ie1.GBRDL()
 	if err != nil {
 		log.Println("Could not read GBRDL!")
+		return err
 	}
 
 	q.qerID = qerID


### PR DESCRIPTION
Malformed QERs should be rejected and an error be signaled back.

We encountered an issue where a buggy SPGW-C is sending corrupted QERs with gate status 5. PFCP agent did not reject those and instead defaulted to gate 0 (open), which allowed traffic to private subnets, instead of dropping it.