### PR TITLE
Fixes for application filtering

### DIFF
--- a/pfcpiface/bess.go
+++ b/pfcpiface/bess.go
@@ -760,7 +760,7 @@ func (b *bess) addQER(ctx context.Context, done chan<- bool, qer qer) {
 		ebs = maxUint64(calcBurstSizeFromRate(qer.dlMbr, uint64(qosVal.burstDurationMs)), uint64(qosVal.ebs))
 		pbs = maxUint64(calcBurstSizeFromRate(qer.dlMbr, uint64(qosVal.burstDurationMs)), uint64(qosVal.ebs))
 
-		if qer.dlStatus == ie.GateStatusClosed {
+		if qer.dlStatus != ie.GateStatusOpen {
 			gate = qerGateStatusDrop
 		} else if qer.dlMbr != 0 || qer.dlGbr != 0 {
 			/* MBR/GBR is received in Kilobits/sec.

--- a/pfcpiface/bess.go
+++ b/pfcpiface/bess.go
@@ -8,7 +8,6 @@ import (
 	"encoding/binary"
 	"flag"
 	"fmt"
-	"math"
 	"net"
 	"strconv"
 	"time"
@@ -623,7 +622,7 @@ func (b *bess) addPDR(ctx context.Context, done chan<- bool, p pdr) {
 
 		f := &pb.WildcardMatchCommandAddArg{
 			Gate:     uint64(p.needDecap),
-			Priority: int64(math.MaxUint32 - p.precedence),
+			Priority: int64(p.precedence),
 			Values: []*pb.FieldData{
 				intEnc(uint64(p.srcIface)),     /* src_iface */
 				intEnc(uint64(p.tunnelIP4Dst)), /* tunnel_ipv4_dst */
@@ -727,7 +726,7 @@ func (b *bess) addQER(ctx context.Context, done chan<- bool, qer qer) {
 		ebs = maxUint64(calcBurstSizeFromRate(qer.ulMbr, uint64(qosVal.burstDurationMs)), uint64(qosVal.ebs))
 		pbs = maxUint64(calcBurstSizeFromRate(qer.ulMbr, uint64(qosVal.burstDurationMs)), uint64(qosVal.ebs))
 
-		if qer.ulStatus == ie.GateStatusClosed {
+		if qer.ulStatus != ie.GateStatusOpen {
 			gate = qerGateStatusDrop
 		} else if qer.ulMbr != 0 || qer.ulGbr != 0 {
 			/* MBR/GBR is received in Kilobits/sec.

--- a/pfcpiface/parse-pdr.go
+++ b/pfcpiface/parse-pdr.go
@@ -71,6 +71,7 @@ func (p pdr) String() string {
 	fmt.Fprintf(&b, "srcPortMask: %x\n", p.srcPortMask)
 	fmt.Fprintf(&b, "dstPortMask: %x\n", p.dstPortMask)
 	fmt.Fprintf(&b, "protoMask: %x\n", p.protoMask)
+	fmt.Fprintf(&b, "precedence: %v\n", p.precedence)
 	fmt.Fprintf(&b, "pdrID: %v\n", p.pdrID)
 	fmt.Fprintf(&b, "fseID: %x\n", p.fseID)
 	fmt.Fprintf(&b, "fseidIP: %v\n", int2ip(p.fseidIP))


### PR DESCRIPTION
This PR introduces two urgent fixes required to unblock the Aether 1.6 release.

It seems there's a bug in `go-pfcp` that causes the QER gate status to be corrupted. Admissible values are 0 (open) and 1 (closed), but we get 5 even if SPGW-C is sending  1.

```
time="2021-12-10T19:55:42Z" level=trace msg="qer: 
qerID: 1073741916
fseID: a5e34e0723c89f22
qfi: 9
fseIDIP: 10.42.45.217
uplinkStatus: 1
downlinkStatus: 5 
uplinkMBR: 100000
downlinkMBR: 100000
uplinkGBR: 0
downlinkGBR: 0
" func="main.(*bess).sendMsgToUPF" file="/pfcpiface/bess.go:163"
```

Fixing `go-pfcp` will take some time, instead we introduce a workaround to treat unrecognized gate statuses as closed (instead of open by default).

Moreover, the previous PDR insertion logic logic was reversing the PDR precedence (`math.MaxUint32 - p.precedence`) when writing lookup entries into BESS. ~Both the PFCP spec and BESS share the same definition for PDR precedence and lookup priority: given multiple entries matching a packet, the entry with the highest precedence (priority) shall be selected.~ After careful revision of the spec, the `math.MaxUint32 - p.precedence` is accurate. In PFCP encoding low precedence values mean higher match priority.

However, we prefer to merge this PR as-is even if it's not spec compliant to unblock the Aether 1.6 release (due this week). Further changes will introduce churn and potentially a new wave of integration issues that might delay the release. We will revert back to `math.MaxUint32 - p.precedence` after the release.