### PR TITLE
Fix golangci-lint (part 1)

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -17,4 +17,8 @@ jobs:
         with:
           version: latest
           working-directory: pfcpiface
-          args: -v --enable-all --disable=nlreturn --max-same-issues=0 --max-issues-per-linter=0
+          # the following are enabled by default:
+          #  deadcode, errcheck, gosimple, govet, ineffassign, staticcheck, structcheck, typecheck, unused, varcheck
+          args:
+            -v --max-same-issues=0 --max-issues-per-linter=0 -E goconst -E goerr113 -E gofmt -E misspell \
+            -E gosec -E goimports -E unparam -E nilnil -E nilerr

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,6 +19,6 @@ jobs:
           working-directory: pfcpiface
           # the following are enabled by default:
           #  deadcode, errcheck, gosimple, govet, ineffassign, staticcheck, structcheck, typecheck, unused, varcheck
-          args:
+          args: |
             -v --max-same-issues=0 --max-issues-per-linter=0 -E goconst -E goerr113 -E gofmt -E misspell \
             -E gosec -E goimports -E unparam -E nilnil -E nilerr

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,5 +20,5 @@ jobs:
           # the following are enabled by default:
           #  deadcode, errcheck, gosimple, govet, ineffassign, staticcheck, structcheck, typecheck, unused, varcheck
           args: |
-            -v --max-same-issues=0 --max-issues-per-linter=0 -E goconst -E goerr113 -E gofmt -E misspell \
-            -E gosec -E goimports -E unparam -E nilnil -E nilerr
+            -v --skip-files ".*\\.pb\\.go" --max-same-issues=0 --max-issues-per-linter=0 -E goconst -E goerr113 \
+            -E gofmt -E misspell -E gosec -E goimports -E unparam -E nilnil -E nilerr

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -13,5 +13,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2.4.0
       - name: golangci-lint
-        run: |
-          make golint
+        uses: golangci/golangci-lint-action@v2.5.2
+        with:
+          version: latest
+          working-directory: pfcpiface
+          args: -v --config ../.golangci.yml

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -13,12 +13,5 @@ jobs:
     steps:
       - uses: actions/checkout@v2.4.0
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2.5.2
-        with:
-          version: latest
-          working-directory: pfcpiface
-          # the following are enabled by default:
-          #  deadcode, errcheck, gosimple, govet, ineffassign, staticcheck, structcheck, typecheck, unused, varcheck
-          args: |
-            -v --skip-files ".*\\.pb\\.go" --max-same-issues=0 --max-issues-per-linter=0 -E goconst -E goerr113 \
-            -E gofmt -E misspell -E gosec -E goimports -E unparam -E nilnil -E nilerr
+        run: |
+          make golint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,19 @@
+# golangci-lint configuration used for CI
+run:
+  tests: true
+  timeout: 10m
+  skip-files:
+    - ".*\\.pb\\.go"
+  skip-dirs-use-default: true
+
+linters:
+  enable:
+    - goconst
+    - gofmt
+    - misspell
+    - gosec
+    - goimports
+    - unparam
+    - nilnil
+    - nilerr
+    - goerr113

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 
 PROJECT_NAME             := upf-epc
 VERSION                  ?= $(shell cat ./VERSION)
+GO_FILES                 := $(shell find . -type d \( -path ./pfcpiface/vendor -o -path ./pfcpiface/bess_pb  \) -prune -o -name '*.go' -print)
 
 # Note that we set the target platform of Docker images to native
 # For a more portable image set CPU=haswell
@@ -69,4 +70,7 @@ pb:
 		.;
 	cp -a output/bess_pb ${BESS_PB_DIR}
 
-.PHONY: docker-build docker-push output pb
+fmt:
+	@gofmt -s -l -w $(GO_FILES)
+
+.PHONY: docker-build docker-push output pb fmt

--- a/Makefile
+++ b/Makefile
@@ -73,4 +73,7 @@ pb:
 fmt:
 	@gofmt -s -l -w $(GO_FILES)
 
-.PHONY: docker-build docker-push output pb fmt
+golint:
+	@docker run --rm -v $(CURDIR):/app -w /app/pfcpiface golangci/golangci-lint:latest golangci-lint run -v --config /app/.golangci.yml
+
+.PHONY: docker-build docker-push output pb fmt lint

--- a/pfcpiface/bess.go
+++ b/pfcpiface/bess.go
@@ -42,7 +42,6 @@ const (
 	farForwardD = 0x0
 	farForwardU = 0x1
 	farDrop     = 0x2
-	farBuffer   = 0x3
 	farNotify   = 0x4
 	// Bit Rates.
 	KB = 1000
@@ -52,16 +51,15 @@ const (
 
 const (
 	// Internal gates for QER.
-	qerGateMeter      uint64 = iota
-	qerGateStatusDrop        = iota + 4
-	qerGateUnmeter
+	qerGateMeter      uint64 = 0
+	qerGateStatusDrop uint64 = 5
+	qerGateUnmeter    uint64 = 6
 )
 
 const (
 	// Internal gates for Slice meter.
-	sliceMeterGateMeter      uint64 = iota
-	sliceMeterGateLookupFail        = iota + 4
-	sliceMeterGateUnmeter
+	sliceMeterGateMeter      uint64 = 0
+	sliceMeterGateUnmeter    uint64 = 6
 )
 
 var intEnc = func(u uint64) *pb.FieldData {

--- a/pfcpiface/bess.go
+++ b/pfcpiface/bess.go
@@ -58,8 +58,8 @@ const (
 
 const (
 	// Internal gates for Slice meter.
-	sliceMeterGateMeter      uint64 = 0
-	sliceMeterGateUnmeter    uint64 = 6
+	sliceMeterGateMeter   uint64 = 0
+	sliceMeterGateUnmeter uint64 = 6
 )
 
 var intEnc = func(u uint64) *pb.FieldData {

--- a/pfcpiface/bess.go
+++ b/pfcpiface/bess.go
@@ -1026,12 +1026,12 @@ func (b *bess) addSliceMeter(ctx context.Context, done chan<- bool, meterConfig 
 
 		q := &pb.QosCommandAddArg{
 			Gate:              gate,
-			Cir:               cir,                               /* committed info rate */
-			Pir:               pir,                               /* peak info rate */
-			Cbs:               cbs,                               /* committed burst size */
-			Pbs:               pbs,                               /* Peak burst size */
-			Ebs:               ebs,                               /* Excess burst size */
-			OptionalDeductLen: &pb.QosCommandAddArg_DeductLen{0}, /* Include all headers */
+			Cir:               cir,                                          /* committed info rate */
+			Pir:               pir,                                          /* peak info rate */
+			Cbs:               cbs,                                          /* committed burst size */
+			Pbs:               pbs,                                          /* Peak burst size */
+			Ebs:               ebs,                                          /* Excess burst size */
+			OptionalDeductLen: &pb.QosCommandAddArg_DeductLen{DeductLen: 0}, /* Include all headers */
 			Fields: []*pb.FieldData{
 				intEnc(uint64(farForwardU)), /* Action */
 				intEnc(uint64(0)),           /* tunnel_out_type */
@@ -1070,12 +1070,12 @@ func (b *bess) addSliceMeter(ctx context.Context, done chan<- bool, meterConfig 
 		// TODO: packet deduction should take GTPU extension header into account
 		q = &pb.QosCommandAddArg{
 			Gate:              gate,
-			Cir:               cir,                                /* committed info rate */
-			Pir:               pir,                                /* peak info rate */
-			Cbs:               cbs,                                /* committed burst size */
-			Pbs:               pbs,                                /* Peak burst size */
-			Ebs:               ebs,                                /* Excess burst size */
-			OptionalDeductLen: &pb.QosCommandAddArg_DeductLen{50}, /* Exclude Ethernet,IP,UDP,GTP header */
+			Cir:               cir,                                           /* committed info rate */
+			Pir:               pir,                                           /* peak info rate */
+			Cbs:               cbs,                                           /* committed burst size */
+			Pbs:               pbs,                                           /* Peak burst size */
+			Ebs:               ebs,                                           /* Excess burst size */
+			OptionalDeductLen: &pb.QosCommandAddArg_DeductLen{DeductLen: 50}, /* Exclude Ethernet,IP,UDP,GTP header */
 			Fields: []*pb.FieldData{
 				intEnc(uint64(farForwardD)), /* Action */
 				intEnc(uint64(1)),           /* tunnel_out_type */

--- a/pfcpiface/conn.go
+++ b/pfcpiface/conn.go
@@ -21,7 +21,6 @@ import (
 const (
 	PFCPPort    = "8805"
 	MaxItems    = 10
-	readTimeout = 25 * time.Second
 )
 
 // Timeout : connection timeout.

--- a/pfcpiface/conn.go
+++ b/pfcpiface/conn.go
@@ -19,8 +19,8 @@ import (
 )
 
 const (
-	PFCPPort    = "8805"
-	MaxItems    = 10
+	PFCPPort = "8805"
+	MaxItems = 10
 )
 
 // Timeout : connection timeout.

--- a/pfcpiface/main.go
+++ b/pfcpiface/main.go
@@ -19,7 +19,6 @@ import (
 
 var (
 	configPath = flag.String("config", "upf.json", "path to upf config")
-	httpAddr   = flag.String("http", "0.0.0.0:8080", "http IP/port combo")
 	simulate   = simModeDisable
 	pfcpsim    = flag.Bool("pfcpsim", false, "simulate PFCP")
 )

--- a/pfcpiface/messages-conn.go
+++ b/pfcpiface/messages-conn.go
@@ -42,14 +42,13 @@ func (pConn *PFCPConn) handleHeartbeatRequest(msg message.Message) (message.Mess
 	return hbres, nil
 }
 
-func (pConn *PFCPConn) handleIncomingResponse(msg message.Message) error {
+func (pConn *PFCPConn) handleIncomingResponse(msg message.Message) {
 	req, ok := pConn.pendingReqs.Load(msg.Sequence())
 
 	if ok {
 		req.(*Request).reply <- msg
 		pConn.pendingReqs.Delete(msg.Sequence())
 	}
-	return nil
 }
 
 func (pConn *PFCPConn) associationIEs() []*ie.IE {

--- a/pfcpiface/messages-session.go
+++ b/pfcpiface/messages-session.go
@@ -22,7 +22,7 @@ const (
 // errors
 var (
 	writeToFastpathErr = errors.New("write to FastPath failed")
-	assocNotFoundErr = errors.New("no association found for NodeID")
+	assocNotFoundErr   = errors.New("no association found for NodeID")
 	allocateSessionErr = errors.New("unable to allocate new PFCP session")
 )
 

--- a/pfcpiface/messages-session.go
+++ b/pfcpiface/messages-session.go
@@ -19,8 +19,12 @@ const (
 	DefaultDDNTimeout = 20
 )
 
-var errAssocNotFound = errors.New("no association found for NodeID")
-var errAllocateSession = errors.New("unable to allocate new PFCP session")
+// errors
+var (
+	writeToFastpathErr = errors.New("write to FastPath failed")
+	assocNotFoundErr = errors.New("no association found for NodeID")
+	allocateSessionErr = errors.New("unable to allocate new PFCP session")
+)
 
 func (pConn *PFCPConn) handleSessionEstablishmentRequest(msg message.Message) (message.Message, error) {
 	upf := pConn.upf
@@ -76,13 +80,13 @@ func (pConn *PFCPConn) handleSessionEstablishmentRequest(msg message.Message) (m
 	if strings.Compare(nodeID, pConn.nodeID.remote) != 0 {
 		log.Warnln("Association not found for Establishment request",
 			"with nodeID: ", nodeID, ", Association NodeID: ", pConn.nodeID.remote)
-		return errProcessReply(errAssocNotFound, ie.CauseNoEstablishedPFCPAssociation)
+		return errProcessReply(assocNotFoundErr, ie.CauseNoEstablishedPFCPAssociation)
 	}
 
 	/* Read CreatePDRs and CreateFARs from payload */
 	localSEID := pConn.NewPFCPSession(remoteSEID)
 	if localSEID == 0 {
-		return errProcessReply(errAllocateSession,
+		return errProcessReply(allocateSessionErr,
 			ie.CauseNoResourcesAvailable)
 	}
 
@@ -110,7 +114,7 @@ func (pConn *PFCPConn) handleSessionEstablishmentRequest(msg message.Message) (m
 
 	for _, cQER := range sereq.CreateQER {
 		var q qer
-		if err := q.parseQER(cQER, session.localSEID, upf); err != nil {
+		if err := q.parseQER(cQER, session.localSEID); err != nil {
 			return errProcessReply(err, ie.CauseRequestRejected)
 		}
 
@@ -123,7 +127,7 @@ func (pConn *PFCPConn) handleSessionEstablishmentRequest(msg message.Message) (m
 	cause := upf.sendMsgToUPF(upfMsgTypeAdd, session.pdrs, session.fars, session.qers)
 	if cause == ie.CauseRequestRejected {
 		pConn.RemoveSession(session.localSEID)
-		return errProcessReply(errors.New("write to FastPath failed"),
+		return errProcessReply(writeToFastpathErr,
 			ie.CauseRequestRejected)
 	}
 
@@ -227,7 +231,7 @@ func (pConn *PFCPConn) handleSessionModificationRequest(msg message.Message) (me
 
 	for _, cQER := range smreq.CreateQER {
 		var q qer
-		if err := q.parseQER(cQER, localSEID, upf); err != nil {
+		if err := q.parseQER(cQER, localSEID); err != nil {
 			return sendError(err)
 		}
 
@@ -285,7 +289,7 @@ func (pConn *PFCPConn) handleSessionModificationRequest(msg message.Message) (me
 			err error
 		)
 
-		if err = q.parseQER(uQER, localSEID, upf); err != nil {
+		if err = q.parseQER(uQER, localSEID); err != nil {
 			return sendError(err)
 		}
 
@@ -304,7 +308,7 @@ func (pConn *PFCPConn) handleSessionModificationRequest(msg message.Message) (me
 
 	cause := upf.sendMsgToUPF(upfMsgTypeMod, addPDRs, addFARs, addQERs)
 	if cause == ie.CauseRequestRejected {
-		return sendError(errors.New("write to FastPath failed"))
+		return sendError(writeToFastpathErr)
 	}
 
 	if session.getNotifyFlag() {
@@ -366,7 +370,7 @@ func (pConn *PFCPConn) handleSessionModificationRequest(msg message.Message) (me
 
 	cause = upf.sendMsgToUPF(upfMsgTypeDel, delPDRs, delFARs, delQERs)
 	if cause == ie.CauseRequestRejected {
-		return sendError(errors.New("write to FastPath failed"))
+		return sendError(writeToFastpathErr)
 	}
 
 	// Build response message
@@ -411,7 +415,7 @@ func (pConn *PFCPConn) handleSessionDeletionRequest(msg message.Message) (messag
 
 	cause := upf.sendMsgToUPF(upfMsgTypeDel, session.pdrs, session.fars, session.qers)
 	if cause == ie.CauseRequestRejected {
-		return sendError(errors.New("write to FastPath failed"))
+		return sendError(writeToFastpathErr)
 	}
 
 	if err := releaseAllocatedIPs(upf.ippool, session); err != nil {
@@ -472,7 +476,7 @@ func (pConn *PFCPConn) handleDigestReport(fseid uint64) {
 	for _, far := range session.fars {
 		if far.farID == farID {
 			if far.applyAction&ActionNotify == 0 {
-				log.Errorln("packet recieved for forwarding far. discard")
+				log.Errorln("packet received for forwarding far. discard")
 				return
 			}
 		}

--- a/pfcpiface/messages.go
+++ b/pfcpiface/messages.go
@@ -97,13 +97,17 @@ func (pConn *PFCPConn) HandlePFCPMsg(buf []byte) {
 		reply, err = pConn.handleSessionModificationRequest(msg)
 	case message.MsgTypeSessionDeletionRequest:
 		reply, err = pConn.handleSessionDeletionRequest(msg)
-	case message.MsgTypeSessionReportResponse:
-		pConn.handleSessionReportResponse(msg)
+	case message.MsgTypeSessionReportResponse: {
+		_, err := pConn.handleSessionReportResponse(msg)
+		if err != nil {
+			log.WithField("error", err).Warn("Failed to handle PFCP session report response, ignoring..")
+		}
+	}
 
 	// Incoming response messages
 	// TODO: Association Setup Request, Session Report Request
 	case message.MsgTypeHeartbeatResponse:
-		err = pConn.handleIncomingResponse(msg)
+		pConn.handleIncomingResponse(msg)
 
 	default:
 		log.Errorln("Message type: ", msgType, " is currently not supported")

--- a/pfcpiface/messages.go
+++ b/pfcpiface/messages.go
@@ -98,12 +98,7 @@ func (pConn *PFCPConn) HandlePFCPMsg(buf []byte) {
 	case message.MsgTypeSessionDeletionRequest:
 		reply, err = pConn.handleSessionDeletionRequest(msg)
 	case message.MsgTypeSessionReportResponse:
-		{
-			_, err := pConn.handleSessionReportResponse(msg)
-			if err != nil {
-				log.WithField("error", err).Warn("Failed to handle PFCP session report response, ignoring..")
-			}
-		}
+		_, err = pConn.handleSessionReportResponse(msg)
 
 	// Incoming response messages
 	// TODO: Association Setup Request, Session Report Request

--- a/pfcpiface/messages.go
+++ b/pfcpiface/messages.go
@@ -97,12 +97,13 @@ func (pConn *PFCPConn) HandlePFCPMsg(buf []byte) {
 		reply, err = pConn.handleSessionModificationRequest(msg)
 	case message.MsgTypeSessionDeletionRequest:
 		reply, err = pConn.handleSessionDeletionRequest(msg)
-	case message.MsgTypeSessionReportResponse: {
-		_, err := pConn.handleSessionReportResponse(msg)
-		if err != nil {
-			log.WithField("error", err).Warn("Failed to handle PFCP session report response, ignoring..")
+	case message.MsgTypeSessionReportResponse:
+		{
+			_, err := pConn.handleSessionReportResponse(msg)
+			if err != nil {
+				log.WithField("error", err).Warn("Failed to handle PFCP session report response, ignoring..")
+			}
 		}
-	}
 
 	// Incoming response messages
 	// TODO: Association Setup Request, Session Report Request

--- a/pfcpiface/node.go
+++ b/pfcpiface/node.go
@@ -123,5 +123,4 @@ func (node *PFCPNode) Serve() {
 func (node *PFCPNode) Done() {
 	<-node.done
 	log.Infoln("Shutdown complete")
-	return
 }

--- a/pfcpiface/p4rt.go
+++ b/pfcpiface/p4rt.go
@@ -168,7 +168,7 @@ func (p *p4rtc) exit() {
 func (p *p4rtc) channelSetup() (*P4rtClient, error) {
 	log.Println("Channel Setup.")
 
-	localclient, errin := CreateChannel(p.host, p.deviceID, p.timeout, p.reportNotifyChan)
+	localclient, errin := CreateChannel(p.host, p.deviceID, p.reportNotifyChan)
 	if errin != nil {
 		log.Println("create channel failed : ", errin)
 		return nil, errin

--- a/pfcpiface/p4rt.go
+++ b/pfcpiface/p4rt.go
@@ -133,7 +133,7 @@ func resetCounterVal(p *p4rtc, counterID uint8, val uint64) {
 	delete(p.counters[counterID].allocated, val)
 }
 
-func getCounterVal(p *p4rtc, counterID uint8, pdrID uint32) (uint64, error) {
+func getCounterVal(p *p4rtc, counterID uint8) (uint64, error) {
 	/*
 	   loop :
 	      random counter generate
@@ -353,8 +353,7 @@ func (p *p4rtc) sendMsgToUPF(
 		{
 			funcType = FunctionTypeInsert
 			for i := range pdrs {
-				val, err = getCounterVal(p,
-					preQosPdrCounter, pdrs[i].pdrID)
+				val, err = getCounterVal(p, preQosPdrCounter)
 				if err != nil {
 					log.Println("Counter id alloc failed ", err)
 					return cause

--- a/pfcpiface/p4rtc.go
+++ b/pfcpiface/p4rtc.go
@@ -171,7 +171,7 @@ func (c *P4rtClient) SendPacketOut(packet []byte) (err error) {
 }
 
 // Init .. Initialize Client.
-func (c *P4rtClient) Init(timeout uint32, reportNotifyChan chan<- uint64) (err error) {
+func (c *P4rtClient) Init(reportNotifyChan chan<- uint64) (err error) {
 	// Initialize stream for mastership and packet I/O
 	// ctx, cancel := context.WithTimeout(context.Background(),
 	//                                   time.Duration(timeout) * time.Second)
@@ -1161,7 +1161,6 @@ func LoadDeviceConfig(deviceConfigPath string) (P4DeviceConfig, error) {
 // CreateChannel ... Create p4runtime client channel.
 func CreateChannel(host string,
 	deviceID uint64,
-	timeout uint32,
 	reportNotifyChan chan<- uint64) (*P4rtClient, error) {
 	log.Println("create channel")
 	// Second, check to see if we can reuse the gRPC connection for a new P4RT client
@@ -1177,7 +1176,7 @@ func CreateChannel(host string,
 		DeviceID: deviceID,
 	}
 
-	err = client.Init(timeout, reportNotifyChan)
+	err = client.Init(reportNotifyChan)
 	if err != nil {
 		log.Println("Client Init error: ", err)
 		return nil, err

--- a/pfcpiface/parse-qer.go
+++ b/pfcpiface/parse-qer.go
@@ -43,7 +43,7 @@ func (q qer) String() string {
 	return b.String()
 }
 
-func (q *qer) parseQER(ie1 *ie.IE, seid uint64, upf *upf) error {
+func (q *qer) parseQER(ie1 *ie.IE, seid uint64) error {
 	qerID, err := ie1.QERID()
 	if err != nil {
 		log.Println("Could not read QER ID!")

--- a/pfcpiface/session-far.go
+++ b/pfcpiface/session-far.go
@@ -104,15 +104,11 @@ func (s *PFCPSession) getNotifyFlag() bool {
 
 func (s *PFCPSession) runTimerForDDNNotify(timeout time.Duration) {
 	endTime := time.After(timeout)
+	for range endTime {
+		log.Println("DDN notify send timeout")
+		s.setNotifyFlag(false)
 
-	for {
-		select {
-		case <-endTime:
-			log.Println("DDN notify send timeout")
-			s.setNotifyFlag(false)
-
-			return
-		}
+		return
 	}
 }
 

--- a/pfcpiface/session-qer.go
+++ b/pfcpiface/session-qer.go
@@ -14,7 +14,6 @@ type QosLevel uint8
 const (
 	ApplicationQos QosLevel = 0
 	SessionQos              = 1
-	CorrelationQos          = 2
 )
 
 // CreateQER appends qer to existing list of QERs in the session.

--- a/pfcpiface/session-qer.go
+++ b/pfcpiface/session-qer.go
@@ -13,7 +13,7 @@ type QosLevel uint8
 
 const (
 	ApplicationQos QosLevel = 0
-	SessionQos              = 1
+	SessionQos     QosLevel = 1
 )
 
 // CreateQER appends qer to existing list of QERs in the session.

--- a/pfcpiface/upf.go
+++ b/pfcpiface/upf.go
@@ -62,7 +62,6 @@ type upf struct {
 // Don't change these values.
 const (
 	tunnelGTPUPort = 2152
-	invalidQerID   = 0xFFFFFFFF
 
 	// src-iface consts.
 	core   = 0x2


### PR DESCRIPTION
This is the first from series of PRs to fix golangci-lint. 

I propose to relax Golangci-lint requirements as they were really strict. My proposal is to use the currently configured linters. We might want to add more linters in the future. 