### PR TITLE
Fix golangci-lint (final)

### DIFF
--- a/pfcpiface/bess.go
+++ b/pfcpiface/bess.go
@@ -11,6 +11,8 @@ import (
 	"strconv"
 	"time"
 
+	"google.golang.org/grpc/credentials/insecure"
+
 	pb "github.com/omec-project/upf-epc/pfcpiface/bess_pb"
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
@@ -529,7 +531,7 @@ func (b *bess) setUpfInfo(u *upf, conf *Conf) {
 
 	b.endMarkerChan = make(chan []byte, 1024)
 
-	b.conn, err = grpc.Dial(*bessIP, grpc.WithInsecure())
+	b.conn, err = grpc.Dial(*bessIP, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		log.Fatalln("did not connect:", err)
 	}

--- a/pfcpiface/conn.go
+++ b/pfcpiface/conn.go
@@ -113,14 +113,14 @@ func (node *PFCPNode) NewPFCPConn(lAddr, rAddr string, buf []byte) *PFCPConn {
 	}
 
 	// TODO: Get SEID range from PFCPNode for this PFCPConn
-
 	log.Infoln("Created PFCPConn from:", conn.LocalAddr(), "to:", conn.RemoteAddr())
 
+	rng := rand.New(rand.NewSource(time.Now().UnixNano())) // #nosec G404
 	p := &PFCPConn{
 		ctx:            node.ctx,
 		Conn:           conn,
 		ts:             ts,
-		rng:            rand.New(rand.NewSource(time.Now().UnixNano())),
+		rng:            rng,
 		maxRetries:     100,
 		sessions:       make(map[uint64]*PFCPSession),
 		upf:            node.upf,

--- a/pfcpiface/messages.go
+++ b/pfcpiface/messages.go
@@ -84,7 +84,7 @@ func (pConn *PFCPConn) HandlePFCPMsg(buf []byte) {
 		}
 		// TODO: Cleanup sessions
 	case message.MsgTypeAssociationSetupResponse:
-		reply, err = pConn.handleAssociationSetupResponse(msg)
+		err = pConn.handleAssociationSetupResponse(msg)
 		// TODO: Cleanup sessions
 		// TODO: start heartbeats
 	case message.MsgTypeAssociationReleaseRequest:
@@ -99,7 +99,7 @@ func (pConn *PFCPConn) HandlePFCPMsg(buf []byte) {
 	case message.MsgTypeSessionDeletionRequest:
 		reply, err = pConn.handleSessionDeletionRequest(msg)
 	case message.MsgTypeSessionReportResponse:
-		_, err = pConn.handleSessionReportResponse(msg)
+		err = pConn.handleSessionReportResponse(msg)
 
 	// Incoming response messages
 	// TODO: Association Setup Request, Session Report Request

--- a/pfcpiface/p4rt.go
+++ b/pfcpiface/p4rt.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"flag"
+	// #nosec G404 // Ignore G404. We don't need strong random number generator for allocating IDs for P4 objects.
 	"math/rand"
 	"net"
 	"time"
@@ -147,7 +148,7 @@ func getCounterVal(p *p4rtc, counterID uint8) (uint64, error) {
 	for i := 0; i < int(ctr.maxSize); i++ {
 		rand.Seed(time.Now().UnixNano())
 
-		val = uint64(rand.Intn(int(ctr.maxSize)-1) + 1)
+		val = uint64(rand.Intn(int(ctr.maxSize)-1) + 1) // #nosec G404
 		if _, ok := ctr.allocated[val]; !ok {
 			log.Println("key not in allocated map ", val)
 

--- a/pfcpiface/p4rtc.go
+++ b/pfcpiface/p4rtc.go
@@ -12,6 +12,11 @@ import (
 	"os"
 	"time"
 
+	"google.golang.org/grpc/credentials/insecure"
+
+	//nolint:staticcheck // Ignore SA1019.
+	// Upgrading to google.golang.org/protobuf/proto is not a drop-in replacement,
+	// as also P4Runtime stubs are based on the deprecated proto.
 	"github.com/golang/protobuf/proto"
 	grpcRetry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
 	p4ConfigV1 "github.com/p4lang/p4runtime/go/p4/config/v1"
@@ -1125,7 +1130,7 @@ func GetConnection(host string) (conn *grpc.ClientConn, err error) {
 	/* get connection */
 	log.Println("Get connection.")
 
-	conn, err = grpc.Dial(host, grpc.WithInsecure())
+	conn, err = grpc.Dial(host, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		log.Println("grpc dial err: ", err)
 		return nil, err


### PR DESCRIPTION
This is the final PR fixing the golangci-lint job and finally closes #382. 

This PR:
- replaces deprecated `grpc.WithInsecure` with `grpc.WithTransportCredentials(insecure.NewCredentials())`
- disables `gosec` for current calls of `math/rand` functions. We don't need strong random number generator for allocating IDs for P4 or PFCP objects.
- disables `staticcheck` for the `proto` package. Upgrading to google.golang.org/protobuf/proto is not a drop-in replacement, as also P4Runtime stubs are based on the deprecated proto. I noticed that this is a practice being used by, e.g. [Prometheus](https://github.com/prometheus/client_golang/blob/master/prometheus/histogram.go#L25). 