### PR TITLE
Fix flow measure reads in no traffic situations

### DIFF
--- a/core/modules/flow_measure.cc
+++ b/core/modules/flow_measure.cc
@@ -14,6 +14,8 @@
 const Commands FlowMeasure::cmds = {
     {"read", "FlowMeasureCommandReadArg",
      MODULE_CMD_FUNC(&FlowMeasure::CommandReadStats), Command::THREAD_SAFE},
+    {"flip", "FlowMeasureCommandFlipArg",
+     MODULE_CMD_FUNC(&FlowMeasure::CommandFlipFlag), Command::THREAD_SAFE},
 };
 /*----------------------------------------------------------------------------------*/
 CommandResponse FlowMeasure::Init(const bess::pb::FlowMeasureArg &arg) {
@@ -160,42 +162,38 @@ void FlowMeasure::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
 /*----------------------------------------------------------------------------------*/
 CommandResponse FlowMeasure::CommandReadStats(
     const bess::pb::FlowMeasureCommandReadArg &arg) {
+  Flag flag_to_read = static_cast<Flag>(arg.flag_to_read());
+  if (!Flag_IsValid(flag_to_read)) {
+    return CommandFailure(EINVAL, "invalid flag value");
+  }
   // Cache current flag so we don't block the dataplane while reading the stats.
   Flag cached_current_flag;
-  // Flip the flag if leader module.
-  if (leader_) {
-    {
-      const std::lock_guard<std::mutex> lock(flag_mutex_);
-      current_flag_value_ = current_flag_value_ == Flag::FLAG_VALUE_A
-                                ? Flag::FLAG_VALUE_B
-                                : Flag::FLAG_VALUE_A;
-      cached_current_flag = current_flag_value_;
-    }
-    VLOG(1) << name() << ": leader flipped the buffer flag to "
-            << Flag_Name(cached_current_flag);
-    // Wait for pipeline to flush packets with old flag value.
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
-  } else {
+  {
     const std::lock_guard<std::mutex> lock(flag_mutex_);
     cached_current_flag = current_flag_value_;
-    VLOG(1) << name() << ": follower is seeing buffer flag "
-            << Flag_Name(cached_current_flag);
   }
+  VLOG(1) << name() << ": " << (leader_ ? "leader" : "follower")
+          << " last saw buffer flag " << Flag_Name(cached_current_flag)
+          << ", now reading from " << Flag_Name(flag_to_read);
+  VLOG_IF(1, cached_current_flag == flag_to_read)
+      << name()
+      << ": requested to read active buffer flag. Either there is no "
+         "traffic or the controller is performing invalid requests.";
 
   bess::pb::FlowMeasureReadResponse resp;
   auto t_start = std::chrono::high_resolution_clock::now();
   rte_hash *current_hash = nullptr;
   std::vector<SessionStats> *current_data = nullptr;
-  switch (cached_current_flag) {  // Pick the offline buffer set.
+  switch (flag_to_read) {
     case Flag::FLAG_VALUE_INVALID:
       return CommandSuccess(resp);  // return empty stats when no traffic
     case Flag::FLAG_VALUE_A:
-      current_hash = table_b_;
-      current_data = &table_data_b_;
-      break;
-    case Flag::FLAG_VALUE_B:
       current_hash = table_a_;
       current_data = &table_data_a_;
+      break;
+    case Flag::FLAG_VALUE_B:
+      current_hash = table_b_;
+      current_data = &table_data_b_;
       break;
     default:
       return CommandFailure(EINVAL, "invalid flag value");
@@ -247,6 +245,32 @@ CommandResponse FlowMeasure::CommandReadStats(
     std::chrono::duration<double> diff = t_done - t_start;
     VLOG(1) << name() << ": CommandReadStats took " << diff.count() << "s.";
   }
+
+  return CommandSuccess(resp);
+}
+
+CommandResponse FlowMeasure::CommandFlipFlag(
+    const bess::pb::FlowMeasureCommandFlipArg &) {
+  // Can only flip the flag if leader module.
+  if (!leader_) {
+    return CommandFailure(EINVAL, "only leaders can flip the flag");
+  }
+  // Cache flags so we block the dataplane as short as possible.
+  Flag cached_old_flag, cached_current_flag;
+  {
+    const std::lock_guard<std::mutex> lock(flag_mutex_);
+    cached_old_flag = current_flag_value_;
+    current_flag_value_ = current_flag_value_ == Flag::FLAG_VALUE_A
+                              ? Flag::FLAG_VALUE_B
+                              : Flag::FLAG_VALUE_A;
+    cached_current_flag = current_flag_value_;
+  }
+  VLOG(1) << name() << ": leader flipped the buffer flag to "
+          << Flag_Name(cached_current_flag);
+  bess::pb::FlowMeasureFlipResponse resp;
+  resp.set_old_flag(static_cast<uint64_t>(cached_old_flag));
+  // Wait for pipeline to flush packets with old flag value.
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
 
   return CommandSuccess(resp);
 }

--- a/core/modules/flow_measure.h
+++ b/core/modules/flow_measure.h
@@ -35,6 +35,8 @@ class FlowMeasure final : public Module {
   std::string GetDesc() const override { return ""; };
   CommandResponse CommandReadStats(
       const bess::pb::FlowMeasureCommandReadArg &arg);
+  CommandResponse CommandFlipFlag(
+      const bess::pb::FlowMeasureCommandFlipArg &arg);
 
  private:
   // Flag represents a collection of possible values to select buffer sides.
@@ -48,7 +50,7 @@ class FlowMeasure final : public Module {
   template <typename T>
   static constexpr bool Flag_IsValid(T value) {
     Flag flag = static_cast<Flag>(value);
-    return flag >= Flag::FLAG_VALUE_INVALID && flag <= Flag::FLAG_VALUE_MAX;
+    return flag > Flag::FLAG_VALUE_INVALID && flag <= Flag::FLAG_VALUE_MAX;
   }
 
   static const std::string Flag_Name(const Flag &flag) {

--- a/patches/bess/0017-QoS-Measure.patch
+++ b/patches/bess/0017-QoS-Measure.patch
@@ -2,7 +2,7 @@ diff --git a/protobuf/module_msg.proto b/protobuf/module_msg.proto
 index c435437a..a6e606f4 100644
 --- a/protobuf/module_msg.proto
 +++ b/protobuf/module_msg.proto
-@@ -1335,3 +1335,35 @@ message QosCommandClearArg {
+@@ -1335,3 +1335,40 @@ message QosCommandClearArg {
  message QosCommandSetDefaultGateArg {
    uint64 gate = 1;
  }
@@ -16,6 +16,7 @@ index c435437a..a6e606f4 100644
 +  bool clear = 1; // If true, the data will be all cleared after read
 +  repeated double latency_percentiles = 2; /// ascending list of real numbers in [0.0, 100.0]
 +  repeated double jitter_percentiles = 3; /// ascending list of real numbers in [0.0, 100.0]
++  uint64 flag_to_read = 4; /// Which buffer to read from
 +}
 +message FlowMeasureReadResponse {
 +  message Statistic {
@@ -37,4 +38,8 @@ index c435437a..a6e606f4 100644
 +    uint64 total_packets = 12;
 +  }
 +  repeated Statistic statistics = 1;
++}
++message FlowMeasureCommandFlipArg {}
++message FlowMeasureFlipResponse {
++  uint64 old_flag = 1;
 +}

--- a/pfcpiface/bess.go
+++ b/pfcpiface/bess.go
@@ -329,13 +329,49 @@ func (b *bess) summaryLatencyJitter(uc *upfCollector, ch chan<- prometheus.Metri
 	measureIface("Core", uc.upf.coreIface)
 }
 
+func (b *bess) flipFlowMeasurementBufferFlag(ctx context.Context, module string) (flip pb.FlowMeasureFlipResponse, err error) {
+	req := &pb.FlowMeasureCommandFlipArg{}
+
+	any, err := anypb.New(req)
+	if err != nil {
+		log.Errorln("Error marshalling request", req, err)
+		return
+	}
+
+	resp, err := b.client.ModuleCommand(
+		ctx, &pb.CommandRequest{
+			Name: module,
+			Cmd:  "flip",
+			Arg:  any,
+		},
+	)
+
+	if err != nil {
+		log.Errorln(module, "read failed!:", err)
+		return
+	}
+
+	if resp.GetError() != nil {
+		log.Errorln(module, "error reading flow stats:", resp.GetError().Errmsg)
+		return
+	}
+
+	if err = resp.Data.UnmarshalTo(&flip); err != nil {
+		log.Errorln(err)
+		return
+	}
+
+	return
+}
+
 func (b *bess) readFlowMeasurement(
-	ctx context.Context, module string, clear bool, q []float64,
+	ctx context.Context, module string, flagToRead uint64, clear bool, q []float64,
 ) (stats pb.FlowMeasureReadResponse, err error) {
 	req := &pb.FlowMeasureCommandReadArg{
 		Clear:              clear,
 		LatencyPercentiles: q,
 		JitterPercentiles:  q,
+		FlagToRead:         flagToRead,
 	}
 
 	any, err := anypb.New(req)
@@ -375,22 +411,29 @@ func (b *bess) sessionStats(uc *upfCollector, ch chan<- prometheus.Metric) (err 
 	// non-blocking for the dataplane anyway.
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
-	// Read stats. This flips the buffer flag, reads from the now inactive side, and clear if needed.
-	q := []float64{50, 90, 99}
-
-	qosStatsInResp, err := b.readFlowMeasurement(ctx, PreQosFlowMeasure, true, q)
+	// Flips the buffer flag, automatically waits for in-flight packets to drain.
+	flip, err := b.flipFlowMeasurementBufferFlag(ctx, PreQosFlowMeasure)
 	if err != nil {
 		log.Errorln(PreQosFlowMeasure, " read failed!:", err)
 		return
 	}
 
-	postDlQosStatsResp, err := b.readFlowMeasurement(ctx, PostDlQosFlowMeasure, true, q)
+	q := []float64{50, 90, 99}
+
+	// Read stats from the now inactive side, and clear if needed.
+	qosStatsInResp, err := b.readFlowMeasurement(ctx, PreQosFlowMeasure, flip.OldFlag, true, q)
+	if err != nil {
+		log.Errorln(PreQosFlowMeasure, " read failed!:", err)
+		return
+	}
+
+	postDlQosStatsResp, err := b.readFlowMeasurement(ctx, PostDlQosFlowMeasure, flip.OldFlag, true, q)
 	if err != nil {
 		log.Errorln(PostDlQosFlowMeasure, " read failed!:", err)
 		return
 	}
 
-	postUlQosStatsResp, err := b.readFlowMeasurement(ctx, PostUlQosFlowMeasure, true, q)
+	postUlQosStatsResp, err := b.readFlowMeasurement(ctx, PostUlQosFlowMeasure, flip.OldFlag, true, q)
 	if err != nil {
 		log.Errorln(PostUlQosFlowMeasure, " read failed!:", err)
 		return

--- a/pfcpiface/bess_pb/module_msg.pb.go
+++ b/pfcpiface/bess_pb/module_msg.pb.go
@@ -6308,6 +6308,7 @@ type FlowMeasureCommandReadArg struct {
 	Clear              bool      `protobuf:"varint,1,opt,name=clear,proto3" json:"clear,omitempty"`                                                             // If true, the data will be all cleared after read
 	LatencyPercentiles []float64 `protobuf:"fixed64,2,rep,packed,name=latency_percentiles,json=latencyPercentiles,proto3" json:"latency_percentiles,omitempty"` /// ascending list of real numbers in [0.0, 100.0]
 	JitterPercentiles  []float64 `protobuf:"fixed64,3,rep,packed,name=jitter_percentiles,json=jitterPercentiles,proto3" json:"jitter_percentiles,omitempty"`    /// ascending list of real numbers in [0.0, 100.0]
+	FlagToRead         uint64    `protobuf:"varint,4,opt,name=flag_to_read,json=flagToRead,proto3" json:"flag_to_read,omitempty"`                               /// Which buffer to read from
 }
 
 func (x *FlowMeasureCommandReadArg) Reset() {
@@ -6363,6 +6364,13 @@ func (x *FlowMeasureCommandReadArg) GetJitterPercentiles() []float64 {
 	return nil
 }
 
+func (x *FlowMeasureCommandReadArg) GetFlagToRead() uint64 {
+	if x != nil {
+		return x.FlagToRead
+	}
+	return 0
+}
+
 type FlowMeasureReadResponse struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -6410,6 +6418,91 @@ func (x *FlowMeasureReadResponse) GetStatistics() []*FlowMeasureReadResponse_Sta
 	return nil
 }
 
+type FlowMeasureCommandFlipArg struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+}
+
+func (x *FlowMeasureCommandFlipArg) Reset() {
+	*x = FlowMeasureCommandFlipArg{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_module_msg_proto_msgTypes[110]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *FlowMeasureCommandFlipArg) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*FlowMeasureCommandFlipArg) ProtoMessage() {}
+
+func (x *FlowMeasureCommandFlipArg) ProtoReflect() protoreflect.Message {
+	mi := &file_module_msg_proto_msgTypes[110]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use FlowMeasureCommandFlipArg.ProtoReflect.Descriptor instead.
+func (*FlowMeasureCommandFlipArg) Descriptor() ([]byte, []int) {
+	return file_module_msg_proto_rawDescGZIP(), []int{110}
+}
+
+type FlowMeasureFlipResponse struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	OldFlag uint64 `protobuf:"varint,1,opt,name=old_flag,json=oldFlag,proto3" json:"old_flag,omitempty"`
+}
+
+func (x *FlowMeasureFlipResponse) Reset() {
+	*x = FlowMeasureFlipResponse{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_module_msg_proto_msgTypes[111]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *FlowMeasureFlipResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*FlowMeasureFlipResponse) ProtoMessage() {}
+
+func (x *FlowMeasureFlipResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_module_msg_proto_msgTypes[111]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use FlowMeasureFlipResponse.ProtoReflect.Descriptor instead.
+func (*FlowMeasureFlipResponse) Descriptor() ([]byte, []int) {
+	return file_module_msg_proto_rawDescGZIP(), []int{111}
+}
+
+func (x *FlowMeasureFlipResponse) GetOldFlag() uint64 {
+	if x != nil {
+		return x.OldFlag
+	}
+	return 0
+}
+
 type L2ForwardCommandAddArg_Entry struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -6422,7 +6515,7 @@ type L2ForwardCommandAddArg_Entry struct {
 func (x *L2ForwardCommandAddArg_Entry) Reset() {
 	*x = L2ForwardCommandAddArg_Entry{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_module_msg_proto_msgTypes[110]
+		mi := &file_module_msg_proto_msgTypes[112]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -6435,7 +6528,7 @@ func (x *L2ForwardCommandAddArg_Entry) String() string {
 func (*L2ForwardCommandAddArg_Entry) ProtoMessage() {}
 
 func (x *L2ForwardCommandAddArg_Entry) ProtoReflect() protoreflect.Message {
-	mi := &file_module_msg_proto_msgTypes[110]
+	mi := &file_module_msg_proto_msgTypes[112]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6483,7 +6576,7 @@ type MeasureCommandGetSummaryResponse_Histogram struct {
 func (x *MeasureCommandGetSummaryResponse_Histogram) Reset() {
 	*x = MeasureCommandGetSummaryResponse_Histogram{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_module_msg_proto_msgTypes[111]
+		mi := &file_module_msg_proto_msgTypes[113]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -6496,7 +6589,7 @@ func (x *MeasureCommandGetSummaryResponse_Histogram) String() string {
 func (*MeasureCommandGetSummaryResponse_Histogram) ProtoMessage() {}
 
 func (x *MeasureCommandGetSummaryResponse_Histogram) ProtoReflect() protoreflect.Message {
-	mi := &file_module_msg_proto_msgTypes[111]
+	mi := &file_module_msg_proto_msgTypes[113]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6586,7 +6679,7 @@ type ACLArg_Rule struct {
 func (x *ACLArg_Rule) Reset() {
 	*x = ACLArg_Rule{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_module_msg_proto_msgTypes[112]
+		mi := &file_module_msg_proto_msgTypes[114]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -6599,7 +6692,7 @@ func (x *ACLArg_Rule) String() string {
 func (*ACLArg_Rule) ProtoMessage() {}
 
 func (x *ACLArg_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_module_msg_proto_msgTypes[112]
+	mi := &file_module_msg_proto_msgTypes[114]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6672,7 +6765,7 @@ type BPFArg_Filter struct {
 func (x *BPFArg_Filter) Reset() {
 	*x = BPFArg_Filter{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_module_msg_proto_msgTypes[113]
+		mi := &file_module_msg_proto_msgTypes[115]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -6685,7 +6778,7 @@ func (x *BPFArg_Filter) String() string {
 func (*BPFArg_Filter) ProtoMessage() {}
 
 func (x *BPFArg_Filter) ProtoReflect() protoreflect.Message {
-	mi := &file_module_msg_proto_msgTypes[113]
+	mi := &file_module_msg_proto_msgTypes[115]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6739,7 +6832,7 @@ type GenericEncapArg_EncapField struct {
 func (x *GenericEncapArg_EncapField) Reset() {
 	*x = GenericEncapArg_EncapField{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_module_msg_proto_msgTypes[114]
+		mi := &file_module_msg_proto_msgTypes[116]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -6752,7 +6845,7 @@ func (x *GenericEncapArg_EncapField) String() string {
 func (*GenericEncapArg_EncapField) ProtoMessage() {}
 
 func (x *GenericEncapArg_EncapField) ProtoReflect() protoreflect.Message {
-	mi := &file_module_msg_proto_msgTypes[114]
+	mi := &file_module_msg_proto_msgTypes[116]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6825,7 +6918,7 @@ type NATArg_PortRange struct {
 func (x *NATArg_PortRange) Reset() {
 	*x = NATArg_PortRange{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_module_msg_proto_msgTypes[118]
+		mi := &file_module_msg_proto_msgTypes[120]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -6838,7 +6931,7 @@ func (x *NATArg_PortRange) String() string {
 func (*NATArg_PortRange) ProtoMessage() {}
 
 func (x *NATArg_PortRange) ProtoReflect() protoreflect.Message {
-	mi := &file_module_msg_proto_msgTypes[118]
+	mi := &file_module_msg_proto_msgTypes[120]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6887,7 +6980,7 @@ type NATArg_ExternalAddress struct {
 func (x *NATArg_ExternalAddress) Reset() {
 	*x = NATArg_ExternalAddress{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_module_msg_proto_msgTypes[119]
+		mi := &file_module_msg_proto_msgTypes[121]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -6900,7 +6993,7 @@ func (x *NATArg_ExternalAddress) String() string {
 func (*NATArg_ExternalAddress) ProtoMessage() {}
 
 func (x *NATArg_ExternalAddress) ProtoReflect() protoreflect.Message {
-	mi := &file_module_msg_proto_msgTypes[119]
+	mi := &file_module_msg_proto_msgTypes[121]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6942,7 +7035,7 @@ type StaticNATArg_AddressRange struct {
 func (x *StaticNATArg_AddressRange) Reset() {
 	*x = StaticNATArg_AddressRange{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_module_msg_proto_msgTypes[120]
+		mi := &file_module_msg_proto_msgTypes[122]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -6955,7 +7048,7 @@ func (x *StaticNATArg_AddressRange) String() string {
 func (*StaticNATArg_AddressRange) ProtoMessage() {}
 
 func (x *StaticNATArg_AddressRange) ProtoReflect() protoreflect.Message {
-	mi := &file_module_msg_proto_msgTypes[120]
+	mi := &file_module_msg_proto_msgTypes[122]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6997,7 +7090,7 @@ type StaticNATArg_AddressRangePair struct {
 func (x *StaticNATArg_AddressRangePair) Reset() {
 	*x = StaticNATArg_AddressRangePair{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_module_msg_proto_msgTypes[121]
+		mi := &file_module_msg_proto_msgTypes[123]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -7010,7 +7103,7 @@ func (x *StaticNATArg_AddressRangePair) String() string {
 func (*StaticNATArg_AddressRangePair) ProtoMessage() {}
 
 func (x *StaticNATArg_AddressRangePair) ProtoReflect() protoreflect.Message {
-	mi := &file_module_msg_proto_msgTypes[121]
+	mi := &file_module_msg_proto_msgTypes[123]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7057,7 +7150,7 @@ type RandomUpdateArg_Field struct {
 func (x *RandomUpdateArg_Field) Reset() {
 	*x = RandomUpdateArg_Field{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_module_msg_proto_msgTypes[122]
+		mi := &file_module_msg_proto_msgTypes[124]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -7070,7 +7163,7 @@ func (x *RandomUpdateArg_Field) String() string {
 func (*RandomUpdateArg_Field) ProtoMessage() {}
 
 func (x *RandomUpdateArg_Field) ProtoReflect() protoreflect.Message {
-	mi := &file_module_msg_proto_msgTypes[122]
+	mi := &file_module_msg_proto_msgTypes[124]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7138,7 +7231,7 @@ type SetMetadataArg_Attribute struct {
 func (x *SetMetadataArg_Attribute) Reset() {
 	*x = SetMetadataArg_Attribute{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_module_msg_proto_msgTypes[123]
+		mi := &file_module_msg_proto_msgTypes[125]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -7151,7 +7244,7 @@ func (x *SetMetadataArg_Attribute) String() string {
 func (*SetMetadataArg_Attribute) ProtoMessage() {}
 
 func (x *SetMetadataArg_Attribute) ProtoReflect() protoreflect.Message {
-	mi := &file_module_msg_proto_msgTypes[123]
+	mi := &file_module_msg_proto_msgTypes[125]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7254,7 +7347,7 @@ type UpdateArg_Field struct {
 func (x *UpdateArg_Field) Reset() {
 	*x = UpdateArg_Field{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_module_msg_proto_msgTypes[124]
+		mi := &file_module_msg_proto_msgTypes[126]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -7267,7 +7360,7 @@ func (x *UpdateArg_Field) String() string {
 func (*UpdateArg_Field) ProtoMessage() {}
 
 func (x *UpdateArg_Field) ProtoReflect() protoreflect.Message {
-	mi := &file_module_msg_proto_msgTypes[124]
+	mi := &file_module_msg_proto_msgTypes[126]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7318,7 +7411,7 @@ type UrlFilterArg_Url struct {
 func (x *UrlFilterArg_Url) Reset() {
 	*x = UrlFilterArg_Url{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_module_msg_proto_msgTypes[125]
+		mi := &file_module_msg_proto_msgTypes[127]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -7331,7 +7424,7 @@ func (x *UrlFilterArg_Url) String() string {
 func (*UrlFilterArg_Url) ProtoMessage() {}
 
 func (x *UrlFilterArg_Url) ProtoReflect() protoreflect.Message {
-	mi := &file_module_msg_proto_msgTypes[125]
+	mi := &file_module_msg_proto_msgTypes[127]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7377,7 +7470,7 @@ type FlowMeasureReadResponse_Statistic struct {
 func (x *FlowMeasureReadResponse_Statistic) Reset() {
 	*x = FlowMeasureReadResponse_Statistic{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_module_msg_proto_msgTypes[127]
+		mi := &file_module_msg_proto_msgTypes[129]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -7390,7 +7483,7 @@ func (x *FlowMeasureReadResponse_Statistic) String() string {
 func (*FlowMeasureReadResponse_Statistic) ProtoMessage() {}
 
 func (x *FlowMeasureReadResponse_Statistic) ProtoReflect() protoreflect.Message {
-	mi := &file_module_msg_proto_msgTypes[127]
+	mi := &file_module_msg_proto_msgTypes[129]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7466,7 +7559,7 @@ type FlowMeasureReadResponse_Statistic_Histogram struct {
 func (x *FlowMeasureReadResponse_Statistic_Histogram) Reset() {
 	*x = FlowMeasureReadResponse_Statistic_Histogram{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_module_msg_proto_msgTypes[128]
+		mi := &file_module_msg_proto_msgTypes[130]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -7479,7 +7572,7 @@ func (x *FlowMeasureReadResponse_Statistic_Histogram) String() string {
 func (*FlowMeasureReadResponse_Statistic_Histogram) ProtoMessage() {}
 
 func (x *FlowMeasureReadResponse_Statistic_Histogram) ProtoReflect() protoreflect.Message {
-	mi := &file_module_msg_proto_msgTypes[128]
+	mi := &file_module_msg_proto_msgTypes[130]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8156,7 +8249,7 @@ var file_module_msg_proto_rawDesc = []byte{
 	0x74, 0x74, 0x72, 0x4e, 0x61, 0x6d, 0x65, 0x12, 0x18, 0x0a, 0x07, 0x65, 0x6e, 0x74, 0x72, 0x69,
 	0x65, 0x73, 0x18, 0x02, 0x20, 0x01, 0x28, 0x04, 0x52, 0x07, 0x65, 0x6e, 0x74, 0x72, 0x69, 0x65,
 	0x73, 0x12, 0x16, 0x0a, 0x06, 0x6c, 0x65, 0x61, 0x64, 0x65, 0x72, 0x18, 0x03, 0x20, 0x01, 0x28,
-	0x08, 0x52, 0x06, 0x6c, 0x65, 0x61, 0x64, 0x65, 0x72, 0x22, 0x91, 0x01, 0x0a, 0x19, 0x46, 0x6c,
+	0x08, 0x52, 0x06, 0x6c, 0x65, 0x61, 0x64, 0x65, 0x72, 0x22, 0xb3, 0x01, 0x0a, 0x19, 0x46, 0x6c,
 	0x6f, 0x77, 0x4d, 0x65, 0x61, 0x73, 0x75, 0x72, 0x65, 0x43, 0x6f, 0x6d, 0x6d, 0x61, 0x6e, 0x64,
 	0x52, 0x65, 0x61, 0x64, 0x41, 0x72, 0x67, 0x12, 0x14, 0x0a, 0x05, 0x63, 0x6c, 0x65, 0x61, 0x72,
 	0x18, 0x01, 0x20, 0x01, 0x28, 0x08, 0x52, 0x05, 0x63, 0x6c, 0x65, 0x61, 0x72, 0x12, 0x2f, 0x0a,
@@ -8165,51 +8258,58 @@ var file_module_msg_proto_rawDesc = []byte{
 	0x6e, 0x63, 0x79, 0x50, 0x65, 0x72, 0x63, 0x65, 0x6e, 0x74, 0x69, 0x6c, 0x65, 0x73, 0x12, 0x2d,
 	0x0a, 0x12, 0x6a, 0x69, 0x74, 0x74, 0x65, 0x72, 0x5f, 0x70, 0x65, 0x72, 0x63, 0x65, 0x6e, 0x74,
 	0x69, 0x6c, 0x65, 0x73, 0x18, 0x03, 0x20, 0x03, 0x28, 0x01, 0x52, 0x11, 0x6a, 0x69, 0x74, 0x74,
-	0x65, 0x72, 0x50, 0x65, 0x72, 0x63, 0x65, 0x6e, 0x74, 0x69, 0x6c, 0x65, 0x73, 0x22, 0xfb, 0x04,
-	0x0a, 0x17, 0x46, 0x6c, 0x6f, 0x77, 0x4d, 0x65, 0x61, 0x73, 0x75, 0x72, 0x65, 0x52, 0x65, 0x61,
-	0x64, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x4a, 0x0a, 0x0a, 0x73, 0x74, 0x61,
-	0x74, 0x69, 0x73, 0x74, 0x69, 0x63, 0x73, 0x18, 0x01, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x2a, 0x2e,
+	0x65, 0x72, 0x50, 0x65, 0x72, 0x63, 0x65, 0x6e, 0x74, 0x69, 0x6c, 0x65, 0x73, 0x12, 0x20, 0x0a,
+	0x0c, 0x66, 0x6c, 0x61, 0x67, 0x5f, 0x74, 0x6f, 0x5f, 0x72, 0x65, 0x61, 0x64, 0x18, 0x04, 0x20,
+	0x01, 0x28, 0x04, 0x52, 0x0a, 0x66, 0x6c, 0x61, 0x67, 0x54, 0x6f, 0x52, 0x65, 0x61, 0x64, 0x22,
+	0xfb, 0x04, 0x0a, 0x17, 0x46, 0x6c, 0x6f, 0x77, 0x4d, 0x65, 0x61, 0x73, 0x75, 0x72, 0x65, 0x52,
+	0x65, 0x61, 0x64, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x4a, 0x0a, 0x0a, 0x73,
+	0x74, 0x61, 0x74, 0x69, 0x73, 0x74, 0x69, 0x63, 0x73, 0x18, 0x01, 0x20, 0x03, 0x28, 0x0b, 0x32,
+	0x2a, 0x2e, 0x62, 0x65, 0x73, 0x73, 0x2e, 0x70, 0x62, 0x2e, 0x46, 0x6c, 0x6f, 0x77, 0x4d, 0x65,
+	0x61, 0x73, 0x75, 0x72, 0x65, 0x52, 0x65, 0x61, 0x64, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73,
+	0x65, 0x2e, 0x53, 0x74, 0x61, 0x74, 0x69, 0x73, 0x74, 0x69, 0x63, 0x52, 0x0a, 0x73, 0x74, 0x61,
+	0x74, 0x69, 0x73, 0x74, 0x69, 0x63, 0x73, 0x1a, 0x93, 0x04, 0x0a, 0x09, 0x53, 0x74, 0x61, 0x74,
+	0x69, 0x73, 0x74, 0x69, 0x63, 0x12, 0x14, 0x0a, 0x05, 0x66, 0x73, 0x65, 0x69, 0x64, 0x18, 0x01,
+	0x20, 0x01, 0x28, 0x04, 0x52, 0x05, 0x66, 0x73, 0x65, 0x69, 0x64, 0x12, 0x10, 0x0a, 0x03, 0x70,
+	0x64, 0x72, 0x18, 0x02, 0x20, 0x01, 0x28, 0x04, 0x52, 0x03, 0x70, 0x64, 0x72, 0x12, 0x4e, 0x0a,
+	0x07, 0x6c, 0x61, 0x74, 0x65, 0x6e, 0x63, 0x79, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x34,
+	0x2e, 0x62, 0x65, 0x73, 0x73, 0x2e, 0x70, 0x62, 0x2e, 0x46, 0x6c, 0x6f, 0x77, 0x4d, 0x65, 0x61,
+	0x73, 0x75, 0x72, 0x65, 0x52, 0x65, 0x61, 0x64, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65,
+	0x2e, 0x53, 0x74, 0x61, 0x74, 0x69, 0x73, 0x74, 0x69, 0x63, 0x2e, 0x48, 0x69, 0x73, 0x74, 0x6f,
+	0x67, 0x72, 0x61, 0x6d, 0x52, 0x07, 0x6c, 0x61, 0x74, 0x65, 0x6e, 0x63, 0x79, 0x12, 0x4c, 0x0a,
+	0x06, 0x6a, 0x69, 0x74, 0x74, 0x65, 0x72, 0x18, 0x04, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x34, 0x2e,
 	0x62, 0x65, 0x73, 0x73, 0x2e, 0x70, 0x62, 0x2e, 0x46, 0x6c, 0x6f, 0x77, 0x4d, 0x65, 0x61, 0x73,
 	0x75, 0x72, 0x65, 0x52, 0x65, 0x61, 0x64, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x2e,
-	0x53, 0x74, 0x61, 0x74, 0x69, 0x73, 0x74, 0x69, 0x63, 0x52, 0x0a, 0x73, 0x74, 0x61, 0x74, 0x69,
-	0x73, 0x74, 0x69, 0x63, 0x73, 0x1a, 0x93, 0x04, 0x0a, 0x09, 0x53, 0x74, 0x61, 0x74, 0x69, 0x73,
-	0x74, 0x69, 0x63, 0x12, 0x14, 0x0a, 0x05, 0x66, 0x73, 0x65, 0x69, 0x64, 0x18, 0x01, 0x20, 0x01,
-	0x28, 0x04, 0x52, 0x05, 0x66, 0x73, 0x65, 0x69, 0x64, 0x12, 0x10, 0x0a, 0x03, 0x70, 0x64, 0x72,
-	0x18, 0x02, 0x20, 0x01, 0x28, 0x04, 0x52, 0x03, 0x70, 0x64, 0x72, 0x12, 0x4e, 0x0a, 0x07, 0x6c,
-	0x61, 0x74, 0x65, 0x6e, 0x63, 0x79, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x34, 0x2e, 0x62,
-	0x65, 0x73, 0x73, 0x2e, 0x70, 0x62, 0x2e, 0x46, 0x6c, 0x6f, 0x77, 0x4d, 0x65, 0x61, 0x73, 0x75,
-	0x72, 0x65, 0x52, 0x65, 0x61, 0x64, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x2e, 0x53,
-	0x74, 0x61, 0x74, 0x69, 0x73, 0x74, 0x69, 0x63, 0x2e, 0x48, 0x69, 0x73, 0x74, 0x6f, 0x67, 0x72,
-	0x61, 0x6d, 0x52, 0x07, 0x6c, 0x61, 0x74, 0x65, 0x6e, 0x63, 0x79, 0x12, 0x4c, 0x0a, 0x06, 0x6a,
-	0x69, 0x74, 0x74, 0x65, 0x72, 0x18, 0x04, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x34, 0x2e, 0x62, 0x65,
-	0x73, 0x73, 0x2e, 0x70, 0x62, 0x2e, 0x46, 0x6c, 0x6f, 0x77, 0x4d, 0x65, 0x61, 0x73, 0x75, 0x72,
-	0x65, 0x52, 0x65, 0x61, 0x64, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x2e, 0x53, 0x74,
-	0x61, 0x74, 0x69, 0x73, 0x74, 0x69, 0x63, 0x2e, 0x48, 0x69, 0x73, 0x74, 0x6f, 0x67, 0x72, 0x61,
-	0x6d, 0x52, 0x06, 0x6a, 0x69, 0x74, 0x74, 0x65, 0x72, 0x12, 0x1f, 0x0a, 0x0b, 0x74, 0x6f, 0x74,
-	0x61, 0x6c, 0x5f, 0x62, 0x79, 0x74, 0x65, 0x73, 0x18, 0x0b, 0x20, 0x01, 0x28, 0x04, 0x52, 0x0a,
-	0x74, 0x6f, 0x74, 0x61, 0x6c, 0x42, 0x79, 0x74, 0x65, 0x73, 0x12, 0x23, 0x0a, 0x0d, 0x74, 0x6f,
-	0x74, 0x61, 0x6c, 0x5f, 0x70, 0x61, 0x63, 0x6b, 0x65, 0x74, 0x73, 0x18, 0x0c, 0x20, 0x01, 0x28,
-	0x04, 0x52, 0x0c, 0x74, 0x6f, 0x74, 0x61, 0x6c, 0x50, 0x61, 0x63, 0x6b, 0x65, 0x74, 0x73, 0x1a,
-	0xf9, 0x01, 0x0a, 0x09, 0x48, 0x69, 0x73, 0x74, 0x6f, 0x67, 0x72, 0x61, 0x6d, 0x12, 0x14, 0x0a,
-	0x05, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x18, 0x01, 0x20, 0x01, 0x28, 0x04, 0x52, 0x05, 0x63, 0x6f,
-	0x75, 0x6e, 0x74, 0x12, 0x1f, 0x0a, 0x0b, 0x61, 0x62, 0x6f, 0x76, 0x65, 0x5f, 0x72, 0x61, 0x6e,
-	0x67, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x04, 0x52, 0x0a, 0x61, 0x62, 0x6f, 0x76, 0x65, 0x52,
-	0x61, 0x6e, 0x67, 0x65, 0x12, 0x23, 0x0a, 0x0d, 0x72, 0x65, 0x73, 0x6f, 0x6c, 0x75, 0x74, 0x69,
-	0x6f, 0x6e, 0x5f, 0x6e, 0x73, 0x18, 0x08, 0x20, 0x01, 0x28, 0x04, 0x52, 0x0c, 0x72, 0x65, 0x73,
-	0x6f, 0x6c, 0x75, 0x74, 0x69, 0x6f, 0x6e, 0x4e, 0x73, 0x12, 0x15, 0x0a, 0x06, 0x6d, 0x69, 0x6e,
-	0x5f, 0x6e, 0x73, 0x18, 0x03, 0x20, 0x01, 0x28, 0x04, 0x52, 0x05, 0x6d, 0x69, 0x6e, 0x4e, 0x73,
-	0x12, 0x15, 0x0a, 0x06, 0x61, 0x76, 0x67, 0x5f, 0x6e, 0x73, 0x18, 0x04, 0x20, 0x01, 0x28, 0x04,
-	0x52, 0x05, 0x61, 0x76, 0x67, 0x4e, 0x73, 0x12, 0x15, 0x0a, 0x06, 0x6d, 0x61, 0x78, 0x5f, 0x6e,
-	0x73, 0x18, 0x05, 0x20, 0x01, 0x28, 0x04, 0x52, 0x05, 0x6d, 0x61, 0x78, 0x4e, 0x73, 0x12, 0x19,
-	0x0a, 0x08, 0x74, 0x6f, 0x74, 0x61, 0x6c, 0x5f, 0x6e, 0x73, 0x18, 0x06, 0x20, 0x01, 0x28, 0x04,
-	0x52, 0x07, 0x74, 0x6f, 0x74, 0x61, 0x6c, 0x4e, 0x73, 0x12, 0x30, 0x0a, 0x14, 0x70, 0x65, 0x72,
-	0x63, 0x65, 0x6e, 0x74, 0x69, 0x6c, 0x65, 0x5f, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x73, 0x5f, 0x6e,
-	0x73, 0x18, 0x07, 0x20, 0x03, 0x28, 0x04, 0x52, 0x12, 0x70, 0x65, 0x72, 0x63, 0x65, 0x6e, 0x74,
-	0x69, 0x6c, 0x65, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x73, 0x4e, 0x73, 0x42, 0x33, 0x5a, 0x31, 0x67,
-	0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x6f, 0x6d, 0x65, 0x63, 0x2d, 0x70,
-	0x72, 0x6f, 0x6a, 0x65, 0x63, 0x74, 0x2f, 0x75, 0x70, 0x66, 0x2d, 0x65, 0x70, 0x63, 0x2f, 0x70,
-	0x66, 0x63, 0x70, 0x69, 0x66, 0x61, 0x63, 0x65, 0x2f, 0x62, 0x65, 0x73, 0x73, 0x5f, 0x70, 0x62,
-	0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
+	0x53, 0x74, 0x61, 0x74, 0x69, 0x73, 0x74, 0x69, 0x63, 0x2e, 0x48, 0x69, 0x73, 0x74, 0x6f, 0x67,
+	0x72, 0x61, 0x6d, 0x52, 0x06, 0x6a, 0x69, 0x74, 0x74, 0x65, 0x72, 0x12, 0x1f, 0x0a, 0x0b, 0x74,
+	0x6f, 0x74, 0x61, 0x6c, 0x5f, 0x62, 0x79, 0x74, 0x65, 0x73, 0x18, 0x0b, 0x20, 0x01, 0x28, 0x04,
+	0x52, 0x0a, 0x74, 0x6f, 0x74, 0x61, 0x6c, 0x42, 0x79, 0x74, 0x65, 0x73, 0x12, 0x23, 0x0a, 0x0d,
+	0x74, 0x6f, 0x74, 0x61, 0x6c, 0x5f, 0x70, 0x61, 0x63, 0x6b, 0x65, 0x74, 0x73, 0x18, 0x0c, 0x20,
+	0x01, 0x28, 0x04, 0x52, 0x0c, 0x74, 0x6f, 0x74, 0x61, 0x6c, 0x50, 0x61, 0x63, 0x6b, 0x65, 0x74,
+	0x73, 0x1a, 0xf9, 0x01, 0x0a, 0x09, 0x48, 0x69, 0x73, 0x74, 0x6f, 0x67, 0x72, 0x61, 0x6d, 0x12,
+	0x14, 0x0a, 0x05, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x18, 0x01, 0x20, 0x01, 0x28, 0x04, 0x52, 0x05,
+	0x63, 0x6f, 0x75, 0x6e, 0x74, 0x12, 0x1f, 0x0a, 0x0b, 0x61, 0x62, 0x6f, 0x76, 0x65, 0x5f, 0x72,
+	0x61, 0x6e, 0x67, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x04, 0x52, 0x0a, 0x61, 0x62, 0x6f, 0x76,
+	0x65, 0x52, 0x61, 0x6e, 0x67, 0x65, 0x12, 0x23, 0x0a, 0x0d, 0x72, 0x65, 0x73, 0x6f, 0x6c, 0x75,
+	0x74, 0x69, 0x6f, 0x6e, 0x5f, 0x6e, 0x73, 0x18, 0x08, 0x20, 0x01, 0x28, 0x04, 0x52, 0x0c, 0x72,
+	0x65, 0x73, 0x6f, 0x6c, 0x75, 0x74, 0x69, 0x6f, 0x6e, 0x4e, 0x73, 0x12, 0x15, 0x0a, 0x06, 0x6d,
+	0x69, 0x6e, 0x5f, 0x6e, 0x73, 0x18, 0x03, 0x20, 0x01, 0x28, 0x04, 0x52, 0x05, 0x6d, 0x69, 0x6e,
+	0x4e, 0x73, 0x12, 0x15, 0x0a, 0x06, 0x61, 0x76, 0x67, 0x5f, 0x6e, 0x73, 0x18, 0x04, 0x20, 0x01,
+	0x28, 0x04, 0x52, 0x05, 0x61, 0x76, 0x67, 0x4e, 0x73, 0x12, 0x15, 0x0a, 0x06, 0x6d, 0x61, 0x78,
+	0x5f, 0x6e, 0x73, 0x18, 0x05, 0x20, 0x01, 0x28, 0x04, 0x52, 0x05, 0x6d, 0x61, 0x78, 0x4e, 0x73,
+	0x12, 0x19, 0x0a, 0x08, 0x74, 0x6f, 0x74, 0x61, 0x6c, 0x5f, 0x6e, 0x73, 0x18, 0x06, 0x20, 0x01,
+	0x28, 0x04, 0x52, 0x07, 0x74, 0x6f, 0x74, 0x61, 0x6c, 0x4e, 0x73, 0x12, 0x30, 0x0a, 0x14, 0x70,
+	0x65, 0x72, 0x63, 0x65, 0x6e, 0x74, 0x69, 0x6c, 0x65, 0x5f, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x73,
+	0x5f, 0x6e, 0x73, 0x18, 0x07, 0x20, 0x03, 0x28, 0x04, 0x52, 0x12, 0x70, 0x65, 0x72, 0x63, 0x65,
+	0x6e, 0x74, 0x69, 0x6c, 0x65, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x73, 0x4e, 0x73, 0x22, 0x1b, 0x0a,
+	0x19, 0x46, 0x6c, 0x6f, 0x77, 0x4d, 0x65, 0x61, 0x73, 0x75, 0x72, 0x65, 0x43, 0x6f, 0x6d, 0x6d,
+	0x61, 0x6e, 0x64, 0x46, 0x6c, 0x69, 0x70, 0x41, 0x72, 0x67, 0x22, 0x34, 0x0a, 0x17, 0x46, 0x6c,
+	0x6f, 0x77, 0x4d, 0x65, 0x61, 0x73, 0x75, 0x72, 0x65, 0x46, 0x6c, 0x69, 0x70, 0x52, 0x65, 0x73,
+	0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x19, 0x0a, 0x08, 0x6f, 0x6c, 0x64, 0x5f, 0x66, 0x6c, 0x61,
+	0x67, 0x18, 0x01, 0x20, 0x01, 0x28, 0x04, 0x52, 0x07, 0x6f, 0x6c, 0x64, 0x46, 0x6c, 0x61, 0x67,
+	0x42, 0x33, 0x5a, 0x31, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x6f,
+	0x6d, 0x65, 0x63, 0x2d, 0x70, 0x72, 0x6f, 0x6a, 0x65, 0x63, 0x74, 0x2f, 0x75, 0x70, 0x66, 0x2d,
+	0x65, 0x70, 0x63, 0x2f, 0x70, 0x66, 0x63, 0x70, 0x69, 0x66, 0x61, 0x63, 0x65, 0x2f, 0x62, 0x65,
+	0x73, 0x73, 0x5f, 0x70, 0x62, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
 }
 
 var (
@@ -8224,7 +8324,7 @@ func file_module_msg_proto_rawDescGZIP() []byte {
 	return file_module_msg_proto_rawDescData
 }
 
-var file_module_msg_proto_msgTypes = make([]protoimpl.MessageInfo, 129)
+var file_module_msg_proto_msgTypes = make([]protoimpl.MessageInfo, 131)
 var file_module_msg_proto_goTypes = []interface{}{
 	(*EmptyArg)(nil),                                    // 0: bess.pb.EmptyArg
 	(*BPFCommandClearArg)(nil),                          // 1: bess.pb.BPFCommandClearArg
@@ -8336,76 +8436,78 @@ var file_module_msg_proto_goTypes = []interface{}{
 	(*FlowMeasureArg)(nil),                              // 107: bess.pb.FlowMeasureArg
 	(*FlowMeasureCommandReadArg)(nil),                   // 108: bess.pb.FlowMeasureCommandReadArg
 	(*FlowMeasureReadResponse)(nil),                     // 109: bess.pb.FlowMeasureReadResponse
-	(*L2ForwardCommandAddArg_Entry)(nil),                // 110: bess.pb.L2ForwardCommandAddArg.Entry
-	(*MeasureCommandGetSummaryResponse_Histogram)(nil),  // 111: bess.pb.MeasureCommandGetSummaryResponse.Histogram
-	(*ACLArg_Rule)(nil),                                 // 112: bess.pb.ACLArg.Rule
-	(*BPFArg_Filter)(nil),                               // 113: bess.pb.BPFArg.Filter
-	(*GenericEncapArg_EncapField)(nil),                  // 114: bess.pb.GenericEncapArg.EncapField
-	nil,                                                 // 115: bess.pb.MetadataTestArg.ReadEntry
-	nil,                                                 // 116: bess.pb.MetadataTestArg.WriteEntry
-	nil,                                                 // 117: bess.pb.MetadataTestArg.UpdateEntry
-	(*NATArg_PortRange)(nil),                            // 118: bess.pb.NATArg.PortRange
-	(*NATArg_ExternalAddress)(nil),                      // 119: bess.pb.NATArg.ExternalAddress
-	(*StaticNATArg_AddressRange)(nil),                   // 120: bess.pb.StaticNATArg.AddressRange
-	(*StaticNATArg_AddressRangePair)(nil),               // 121: bess.pb.StaticNATArg.AddressRangePair
-	(*RandomUpdateArg_Field)(nil),                       // 122: bess.pb.RandomUpdateArg.Field
-	(*SetMetadataArg_Attribute)(nil),                    // 123: bess.pb.SetMetadataArg.Attribute
-	(*UpdateArg_Field)(nil),                             // 124: bess.pb.UpdateArg.Field
-	(*UrlFilterArg_Url)(nil),                            // 125: bess.pb.UrlFilterArg.Url
-	nil,                                                 // 126: bess.pb.WorkerSplitArg.WorkerGatesEntry
-	(*FlowMeasureReadResponse_Statistic)(nil),           // 127: bess.pb.FlowMeasureReadResponse.Statistic
-	(*FlowMeasureReadResponse_Statistic_Histogram)(nil), // 128: bess.pb.FlowMeasureReadResponse.Statistic.Histogram
-	(*FieldData)(nil),                                   // 129: bess.pb.FieldData
-	(*Field)(nil),                                       // 130: bess.pb.Field
+	(*FlowMeasureCommandFlipArg)(nil),                   // 110: bess.pb.FlowMeasureCommandFlipArg
+	(*FlowMeasureFlipResponse)(nil),                     // 111: bess.pb.FlowMeasureFlipResponse
+	(*L2ForwardCommandAddArg_Entry)(nil),                // 112: bess.pb.L2ForwardCommandAddArg.Entry
+	(*MeasureCommandGetSummaryResponse_Histogram)(nil),  // 113: bess.pb.MeasureCommandGetSummaryResponse.Histogram
+	(*ACLArg_Rule)(nil),                                 // 114: bess.pb.ACLArg.Rule
+	(*BPFArg_Filter)(nil),                               // 115: bess.pb.BPFArg.Filter
+	(*GenericEncapArg_EncapField)(nil),                  // 116: bess.pb.GenericEncapArg.EncapField
+	nil,                                                 // 117: bess.pb.MetadataTestArg.ReadEntry
+	nil,                                                 // 118: bess.pb.MetadataTestArg.WriteEntry
+	nil,                                                 // 119: bess.pb.MetadataTestArg.UpdateEntry
+	(*NATArg_PortRange)(nil),                            // 120: bess.pb.NATArg.PortRange
+	(*NATArg_ExternalAddress)(nil),                      // 121: bess.pb.NATArg.ExternalAddress
+	(*StaticNATArg_AddressRange)(nil),                   // 122: bess.pb.StaticNATArg.AddressRange
+	(*StaticNATArg_AddressRangePair)(nil),               // 123: bess.pb.StaticNATArg.AddressRangePair
+	(*RandomUpdateArg_Field)(nil),                       // 124: bess.pb.RandomUpdateArg.Field
+	(*SetMetadataArg_Attribute)(nil),                    // 125: bess.pb.SetMetadataArg.Attribute
+	(*UpdateArg_Field)(nil),                             // 126: bess.pb.UpdateArg.Field
+	(*UrlFilterArg_Url)(nil),                            // 127: bess.pb.UrlFilterArg.Url
+	nil,                                                 // 128: bess.pb.WorkerSplitArg.WorkerGatesEntry
+	(*FlowMeasureReadResponse_Statistic)(nil),           // 129: bess.pb.FlowMeasureReadResponse.Statistic
+	(*FlowMeasureReadResponse_Statistic_Histogram)(nil), // 130: bess.pb.FlowMeasureReadResponse.Statistic.Histogram
+	(*FieldData)(nil),                                   // 131: bess.pb.FieldData
+	(*Field)(nil),                                       // 132: bess.pb.Field
 }
 var file_module_msg_proto_depIdxs = []int32{
-	129, // 0: bess.pb.ExactMatchCommandAddArg.fields:type_name -> bess.pb.FieldData
-	129, // 1: bess.pb.ExactMatchCommandAddArg.values:type_name -> bess.pb.FieldData
-	129, // 2: bess.pb.ExactMatchCommandDeleteArg.fields:type_name -> bess.pb.FieldData
-	130, // 3: bess.pb.HashLBCommandSetModeArg.fields:type_name -> bess.pb.Field
-	110, // 4: bess.pb.L2ForwardCommandAddArg.entries:type_name -> bess.pb.L2ForwardCommandAddArg.Entry
-	111, // 5: bess.pb.MeasureCommandGetSummaryResponse.latency:type_name -> bess.pb.MeasureCommandGetSummaryResponse.Histogram
-	111, // 6: bess.pb.MeasureCommandGetSummaryResponse.jitter:type_name -> bess.pb.MeasureCommandGetSummaryResponse.Histogram
-	129, // 7: bess.pb.WildcardMatchCommandAddArg.values:type_name -> bess.pb.FieldData
-	129, // 8: bess.pb.WildcardMatchCommandAddArg.masks:type_name -> bess.pb.FieldData
-	129, // 9: bess.pb.WildcardMatchCommandAddArg.valuesv:type_name -> bess.pb.FieldData
-	129, // 10: bess.pb.WildcardMatchCommandDeleteArg.values:type_name -> bess.pb.FieldData
-	129, // 11: bess.pb.WildcardMatchCommandDeleteArg.masks:type_name -> bess.pb.FieldData
-	112, // 12: bess.pb.ACLArg.rules:type_name -> bess.pb.ACLArg.Rule
-	113, // 13: bess.pb.BPFArg.filters:type_name -> bess.pb.BPFArg.Filter
-	130, // 14: bess.pb.ExactMatchArg.fields:type_name -> bess.pb.Field
-	129, // 15: bess.pb.ExactMatchArg.masks:type_name -> bess.pb.FieldData
-	130, // 16: bess.pb.ExactMatchArg.values:type_name -> bess.pb.Field
-	129, // 17: bess.pb.ExactMatchArg.masksv:type_name -> bess.pb.FieldData
+	131, // 0: bess.pb.ExactMatchCommandAddArg.fields:type_name -> bess.pb.FieldData
+	131, // 1: bess.pb.ExactMatchCommandAddArg.values:type_name -> bess.pb.FieldData
+	131, // 2: bess.pb.ExactMatchCommandDeleteArg.fields:type_name -> bess.pb.FieldData
+	132, // 3: bess.pb.HashLBCommandSetModeArg.fields:type_name -> bess.pb.Field
+	112, // 4: bess.pb.L2ForwardCommandAddArg.entries:type_name -> bess.pb.L2ForwardCommandAddArg.Entry
+	113, // 5: bess.pb.MeasureCommandGetSummaryResponse.latency:type_name -> bess.pb.MeasureCommandGetSummaryResponse.Histogram
+	113, // 6: bess.pb.MeasureCommandGetSummaryResponse.jitter:type_name -> bess.pb.MeasureCommandGetSummaryResponse.Histogram
+	131, // 7: bess.pb.WildcardMatchCommandAddArg.values:type_name -> bess.pb.FieldData
+	131, // 8: bess.pb.WildcardMatchCommandAddArg.masks:type_name -> bess.pb.FieldData
+	131, // 9: bess.pb.WildcardMatchCommandAddArg.valuesv:type_name -> bess.pb.FieldData
+	131, // 10: bess.pb.WildcardMatchCommandDeleteArg.values:type_name -> bess.pb.FieldData
+	131, // 11: bess.pb.WildcardMatchCommandDeleteArg.masks:type_name -> bess.pb.FieldData
+	114, // 12: bess.pb.ACLArg.rules:type_name -> bess.pb.ACLArg.Rule
+	115, // 13: bess.pb.BPFArg.filters:type_name -> bess.pb.BPFArg.Filter
+	132, // 14: bess.pb.ExactMatchArg.fields:type_name -> bess.pb.Field
+	131, // 15: bess.pb.ExactMatchArg.masks:type_name -> bess.pb.FieldData
+	132, // 16: bess.pb.ExactMatchArg.values:type_name -> bess.pb.Field
+	131, // 17: bess.pb.ExactMatchArg.masksv:type_name -> bess.pb.FieldData
 	2,   // 18: bess.pb.ExactMatchConfig.rules:type_name -> bess.pb.ExactMatchCommandAddArg
-	114, // 19: bess.pb.GenericEncapArg.fields:type_name -> bess.pb.GenericEncapArg.EncapField
-	130, // 20: bess.pb.HashLBArg.fields:type_name -> bess.pb.Field
-	115, // 21: bess.pb.MetadataTestArg.read:type_name -> bess.pb.MetadataTestArg.ReadEntry
-	116, // 22: bess.pb.MetadataTestArg.write:type_name -> bess.pb.MetadataTestArg.WriteEntry
-	117, // 23: bess.pb.MetadataTestArg.update:type_name -> bess.pb.MetadataTestArg.UpdateEntry
-	119, // 24: bess.pb.NATArg.ext_addrs:type_name -> bess.pb.NATArg.ExternalAddress
-	121, // 25: bess.pb.StaticNATArg.pairs:type_name -> bess.pb.StaticNATArg.AddressRangePair
-	122, // 26: bess.pb.RandomUpdateArg.fields:type_name -> bess.pb.RandomUpdateArg.Field
-	123, // 27: bess.pb.SetMetadataArg.attrs:type_name -> bess.pb.SetMetadataArg.Attribute
-	124, // 28: bess.pb.UpdateArg.fields:type_name -> bess.pb.UpdateArg.Field
-	125, // 29: bess.pb.UrlFilterArg.blacklist:type_name -> bess.pb.UrlFilterArg.Url
-	125, // 30: bess.pb.UrlFilterConfig.blacklist:type_name -> bess.pb.UrlFilterArg.Url
-	130, // 31: bess.pb.WildcardMatchArg.fields:type_name -> bess.pb.Field
-	130, // 32: bess.pb.WildcardMatchArg.values:type_name -> bess.pb.Field
+	116, // 19: bess.pb.GenericEncapArg.fields:type_name -> bess.pb.GenericEncapArg.EncapField
+	132, // 20: bess.pb.HashLBArg.fields:type_name -> bess.pb.Field
+	117, // 21: bess.pb.MetadataTestArg.read:type_name -> bess.pb.MetadataTestArg.ReadEntry
+	118, // 22: bess.pb.MetadataTestArg.write:type_name -> bess.pb.MetadataTestArg.WriteEntry
+	119, // 23: bess.pb.MetadataTestArg.update:type_name -> bess.pb.MetadataTestArg.UpdateEntry
+	121, // 24: bess.pb.NATArg.ext_addrs:type_name -> bess.pb.NATArg.ExternalAddress
+	123, // 25: bess.pb.StaticNATArg.pairs:type_name -> bess.pb.StaticNATArg.AddressRangePair
+	124, // 26: bess.pb.RandomUpdateArg.fields:type_name -> bess.pb.RandomUpdateArg.Field
+	125, // 27: bess.pb.SetMetadataArg.attrs:type_name -> bess.pb.SetMetadataArg.Attribute
+	126, // 28: bess.pb.UpdateArg.fields:type_name -> bess.pb.UpdateArg.Field
+	127, // 29: bess.pb.UrlFilterArg.blacklist:type_name -> bess.pb.UrlFilterArg.Url
+	127, // 30: bess.pb.UrlFilterConfig.blacklist:type_name -> bess.pb.UrlFilterArg.Url
+	132, // 31: bess.pb.WildcardMatchArg.fields:type_name -> bess.pb.Field
+	132, // 32: bess.pb.WildcardMatchArg.values:type_name -> bess.pb.Field
 	32,  // 33: bess.pb.WildcardMatchConfig.rules:type_name -> bess.pb.WildcardMatchCommandAddArg
-	126, // 34: bess.pb.WorkerSplitArg.worker_gates:type_name -> bess.pb.WorkerSplitArg.WorkerGatesEntry
-	130, // 35: bess.pb.QosArg.fields:type_name -> bess.pb.Field
-	130, // 36: bess.pb.QosArg.values:type_name -> bess.pb.Field
-	129, // 37: bess.pb.QosCommandAddArg.fields:type_name -> bess.pb.FieldData
-	129, // 38: bess.pb.QosCommandAddArg.values:type_name -> bess.pb.FieldData
-	129, // 39: bess.pb.QosCommandDeleteArg.fields:type_name -> bess.pb.FieldData
-	127, // 40: bess.pb.FlowMeasureReadResponse.statistics:type_name -> bess.pb.FlowMeasureReadResponse.Statistic
-	129, // 41: bess.pb.GenericEncapArg.EncapField.value:type_name -> bess.pb.FieldData
-	118, // 42: bess.pb.NATArg.ExternalAddress.port_ranges:type_name -> bess.pb.NATArg.PortRange
-	120, // 43: bess.pb.StaticNATArg.AddressRangePair.int_range:type_name -> bess.pb.StaticNATArg.AddressRange
-	120, // 44: bess.pb.StaticNATArg.AddressRangePair.ext_range:type_name -> bess.pb.StaticNATArg.AddressRange
-	128, // 45: bess.pb.FlowMeasureReadResponse.Statistic.latency:type_name -> bess.pb.FlowMeasureReadResponse.Statistic.Histogram
-	128, // 46: bess.pb.FlowMeasureReadResponse.Statistic.jitter:type_name -> bess.pb.FlowMeasureReadResponse.Statistic.Histogram
+	128, // 34: bess.pb.WorkerSplitArg.worker_gates:type_name -> bess.pb.WorkerSplitArg.WorkerGatesEntry
+	132, // 35: bess.pb.QosArg.fields:type_name -> bess.pb.Field
+	132, // 36: bess.pb.QosArg.values:type_name -> bess.pb.Field
+	131, // 37: bess.pb.QosCommandAddArg.fields:type_name -> bess.pb.FieldData
+	131, // 38: bess.pb.QosCommandAddArg.values:type_name -> bess.pb.FieldData
+	131, // 39: bess.pb.QosCommandDeleteArg.fields:type_name -> bess.pb.FieldData
+	129, // 40: bess.pb.FlowMeasureReadResponse.statistics:type_name -> bess.pb.FlowMeasureReadResponse.Statistic
+	131, // 41: bess.pb.GenericEncapArg.EncapField.value:type_name -> bess.pb.FieldData
+	120, // 42: bess.pb.NATArg.ExternalAddress.port_ranges:type_name -> bess.pb.NATArg.PortRange
+	122, // 43: bess.pb.StaticNATArg.AddressRangePair.int_range:type_name -> bess.pb.StaticNATArg.AddressRange
+	122, // 44: bess.pb.StaticNATArg.AddressRangePair.ext_range:type_name -> bess.pb.StaticNATArg.AddressRange
+	130, // 45: bess.pb.FlowMeasureReadResponse.Statistic.latency:type_name -> bess.pb.FlowMeasureReadResponse.Statistic.Histogram
+	130, // 46: bess.pb.FlowMeasureReadResponse.Statistic.jitter:type_name -> bess.pb.FlowMeasureReadResponse.Statistic.Histogram
 	47,  // [47:47] is the sub-list for method output_type
 	47,  // [47:47] is the sub-list for method input_type
 	47,  // [47:47] is the sub-list for extension type_name
@@ -9741,7 +9843,7 @@ func file_module_msg_proto_init() {
 			}
 		}
 		file_module_msg_proto_msgTypes[110].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*L2ForwardCommandAddArg_Entry); i {
+			switch v := v.(*FlowMeasureCommandFlipArg); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -9753,7 +9855,7 @@ func file_module_msg_proto_init() {
 			}
 		}
 		file_module_msg_proto_msgTypes[111].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*MeasureCommandGetSummaryResponse_Histogram); i {
+			switch v := v.(*FlowMeasureFlipResponse); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -9765,7 +9867,7 @@ func file_module_msg_proto_init() {
 			}
 		}
 		file_module_msg_proto_msgTypes[112].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*ACLArg_Rule); i {
+			switch v := v.(*L2ForwardCommandAddArg_Entry); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -9777,7 +9879,7 @@ func file_module_msg_proto_init() {
 			}
 		}
 		file_module_msg_proto_msgTypes[113].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*BPFArg_Filter); i {
+			switch v := v.(*MeasureCommandGetSummaryResponse_Histogram); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -9789,6 +9891,30 @@ func file_module_msg_proto_init() {
 			}
 		}
 		file_module_msg_proto_msgTypes[114].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*ACLArg_Rule); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_module_msg_proto_msgTypes[115].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*BPFArg_Filter); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_module_msg_proto_msgTypes[116].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*GenericEncapArg_EncapField); i {
 			case 0:
 				return &v.state
@@ -9800,7 +9926,7 @@ func file_module_msg_proto_init() {
 				return nil
 			}
 		}
-		file_module_msg_proto_msgTypes[118].Exporter = func(v interface{}, i int) interface{} {
+		file_module_msg_proto_msgTypes[120].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*NATArg_PortRange); i {
 			case 0:
 				return &v.state
@@ -9812,7 +9938,7 @@ func file_module_msg_proto_init() {
 				return nil
 			}
 		}
-		file_module_msg_proto_msgTypes[119].Exporter = func(v interface{}, i int) interface{} {
+		file_module_msg_proto_msgTypes[121].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*NATArg_ExternalAddress); i {
 			case 0:
 				return &v.state
@@ -9824,7 +9950,7 @@ func file_module_msg_proto_init() {
 				return nil
 			}
 		}
-		file_module_msg_proto_msgTypes[120].Exporter = func(v interface{}, i int) interface{} {
+		file_module_msg_proto_msgTypes[122].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*StaticNATArg_AddressRange); i {
 			case 0:
 				return &v.state
@@ -9836,7 +9962,7 @@ func file_module_msg_proto_init() {
 				return nil
 			}
 		}
-		file_module_msg_proto_msgTypes[121].Exporter = func(v interface{}, i int) interface{} {
+		file_module_msg_proto_msgTypes[123].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*StaticNATArg_AddressRangePair); i {
 			case 0:
 				return &v.state
@@ -9848,7 +9974,7 @@ func file_module_msg_proto_init() {
 				return nil
 			}
 		}
-		file_module_msg_proto_msgTypes[122].Exporter = func(v interface{}, i int) interface{} {
+		file_module_msg_proto_msgTypes[124].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*RandomUpdateArg_Field); i {
 			case 0:
 				return &v.state
@@ -9860,7 +9986,7 @@ func file_module_msg_proto_init() {
 				return nil
 			}
 		}
-		file_module_msg_proto_msgTypes[123].Exporter = func(v interface{}, i int) interface{} {
+		file_module_msg_proto_msgTypes[125].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*SetMetadataArg_Attribute); i {
 			case 0:
 				return &v.state
@@ -9872,7 +9998,7 @@ func file_module_msg_proto_init() {
 				return nil
 			}
 		}
-		file_module_msg_proto_msgTypes[124].Exporter = func(v interface{}, i int) interface{} {
+		file_module_msg_proto_msgTypes[126].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*UpdateArg_Field); i {
 			case 0:
 				return &v.state
@@ -9884,7 +10010,7 @@ func file_module_msg_proto_init() {
 				return nil
 			}
 		}
-		file_module_msg_proto_msgTypes[125].Exporter = func(v interface{}, i int) interface{} {
+		file_module_msg_proto_msgTypes[127].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*UrlFilterArg_Url); i {
 			case 0:
 				return &v.state
@@ -9896,7 +10022,7 @@ func file_module_msg_proto_init() {
 				return nil
 			}
 		}
-		file_module_msg_proto_msgTypes[127].Exporter = func(v interface{}, i int) interface{} {
+		file_module_msg_proto_msgTypes[129].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*FlowMeasureReadResponse_Statistic); i {
 			case 0:
 				return &v.state
@@ -9908,7 +10034,7 @@ func file_module_msg_proto_init() {
 				return nil
 			}
 		}
-		file_module_msg_proto_msgTypes[128].Exporter = func(v interface{}, i int) interface{} {
+		file_module_msg_proto_msgTypes[130].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*FlowMeasureReadResponse_Statistic_Histogram); i {
 			case 0:
 				return &v.state
@@ -9936,11 +10062,11 @@ func file_module_msg_proto_init() {
 	file_module_msg_proto_msgTypes[103].OneofWrappers = []interface{}{
 		(*QosCommandAddArg_DeductLen)(nil),
 	}
-	file_module_msg_proto_msgTypes[114].OneofWrappers = []interface{}{
+	file_module_msg_proto_msgTypes[116].OneofWrappers = []interface{}{
 		(*GenericEncapArg_EncapField_Attribute)(nil),
 		(*GenericEncapArg_EncapField_Value)(nil),
 	}
-	file_module_msg_proto_msgTypes[123].OneofWrappers = []interface{}{
+	file_module_msg_proto_msgTypes[125].OneofWrappers = []interface{}{
 		(*SetMetadataArg_Attribute_ValueInt)(nil),
 		(*SetMetadataArg_Attribute_ValueBin)(nil),
 	}
@@ -9950,7 +10076,7 @@ func file_module_msg_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_module_msg_proto_rawDesc,
 			NumEnums:      0,
-			NumMessages:   129,
+			NumMessages:   131,
 			NumExtensions: 0,
 			NumServices:   0,
 		},


### PR DESCRIPTION
When there is no traffic flowing though the pipeline, the in-band mechanism of attaching the current buffer side to packets can't be used. Instead, we have to flip the flag and tell the module which side to read explicitly from the controller/agent side.

Steps to reproduce:
- Start and simulate: `./docker_setup.sh && docker exec -ti bess-pfcpiface pfcpiface -config /conf/upf.json -simulate create`
- Refresh prometheus page to read stats
- Stop traffic flow: `docker exec -ti bess-pfcpiface pfcpiface -config /conf/upf.json -simulate delete`
- Refresh page again, shows incorrect results
