### PR TITLE
Update upf-k8s yaml.

### DIFF
--- a/upf-k8s.yaml
+++ b/upf-k8s.yaml
@@ -55,7 +55,7 @@ data:
       "measure_upf": true,
       "workers": "1",
       "cpiface": {
-        "dnn": "internet",
+        "dnn": "internet"
       }
     }
 ---

--- a/upf-k8s.yaml
+++ b/upf-k8s.yaml
@@ -46,19 +46,6 @@ metadata:
 data:
   upf.json: |
     {
-      "table_sizes": {
-        "": "Example sizes based on sim mode and 50K sessions. Customize as per your control plane",
-        "": "50K per unique tuple, we send 4 unique PDR patterns",
-        "pdrLookup": 50000,
-        "": "4 PDRs per session",
-        "flowMeasure": 200000,
-        "": "there are 2 QERs and 2 entries per QER",
-        "appQERLookup": 200000,
-        "": "there is 1 session QER and 2 entries per session QER",
-        "sessionQERLookup": 100000,
-        "": "there are 3 FARs",
-        "farLookup": 150000
-      },
       "access": {
         "ifname": "access"
       },
@@ -69,11 +56,6 @@ data:
       "workers": "1",
       "cpiface": {
         "dnn": "internet",
-        "http_port": "8080",
-        "enable_ue_ip_alloc": false,
-        "ue_ip_pool": "10.250.0.0/16",
-        "" : "use_fqdn: true",
-        "" : "hostname: upf-0"
       }
     }
 ---

--- a/upf-k8s.yaml
+++ b/upf-k8s.yaml
@@ -2,13 +2,14 @@
 apiVersion: "k8s.cni.cncf.io/v1"
 kind: NetworkAttachmentDefinition
 metadata:
-  name: s1u-net
+  name: access-net
   annotations:
-    k8s.v1.cni.cncf.io/resourceName: intel.com/sriov_vfio_s1u_net
+    k8s.v1.cni.cncf.io/resourceName: intel.com/sriov_vfio_access_net
 spec:
   config: '{
+    "cniVersion": "0.3.1",
     "type": "vfioveth",
-    "name": "s1u-net",
+    "name": "access-net",
     "ipam": {
         "type": "host-local",
         "subnet": "198.18.0.0/24",
@@ -21,13 +22,14 @@ spec:
 apiVersion: "k8s.cni.cncf.io/v1"
 kind: NetworkAttachmentDefinition
 metadata:
-  name: sgi-net
+  name: core-net
   annotations:
-    k8s.v1.cni.cncf.io/resourceName: intel.com/sriov_vfio_sgi_net
+    k8s.v1.cni.cncf.io/resourceName: intel.com/sriov_vfio_core_net
 spec:
   config: '{
+    "cniVersion": "0.3.1",
     "type": "vfioveth",
-    "name": "sgi-net",
+    "name": "core-net",
     "ipam": {
         "type": "host-local",
         "subnet": "198.19.0.0/24",
@@ -44,14 +46,35 @@ metadata:
 data:
   upf.json: |
     {
-      "s1u": {
-        "ifname": "s1u"
+      "table_sizes": {
+        "": "Example sizes based on sim mode and 50K sessions. Customize as per your control plane",
+        "": "50K per unique tuple, we send 4 unique PDR patterns",
+        "pdrLookup": 50000,
+        "": "4 PDRs per session",
+        "flowMeasure": 200000,
+        "": "there are 2 QERs and 2 entries per QER",
+        "appQERLookup": 200000,
+        "": "there is 1 session QER and 2 entries per session QER",
+        "sessionQERLookup": 100000,
+        "": "there are 3 FARs",
+        "farLookup": 150000
       },
-      "sgi": {
-        "ifname": "sgi"
+      "access": {
+        "ifname": "access"
+      },
+      "core": {
+        "ifname": "core"
       },
       "measure_upf": true,
       "workers": "1",
+      "cpiface": {
+        "dnn": "internet",
+        "http_port": "8080",
+        "enable_ue_ip_alloc": false,
+        "ue_ip_pool": "10.250.0.0/16",
+        "" : "use_fqdn: true",
+        "" : "hostname: upf-0"
+      }
     }
 ---
 apiVersion: v1
@@ -64,8 +87,8 @@ metadata:
       prometheus.io/scrape: "true"
       prometheus.io/port: "8080"
       k8s.v1.cni.cncf.io/networks: '[
-            { "name": "s1u-net", "interface": "s1u" },
-            { "name": "sgi-net", "interface": "sgi" }
+            { "name": "access-net", "interface": "access" },
+            { "name": "core-net", "interface": "core" }
     ]'
 spec:
   shareProcessNamespace: true
@@ -105,8 +128,8 @@ spec:
     command: ["/opt/bess/bessctl/conf/route_control.py"]
     args:
     - -i
-    - s1u
-    - sgi
+    - access
+    - core
     env:
     - name: PYTHONUNBUFFERED
       value: "1"
@@ -141,8 +164,8 @@ spec:
         hugepages-1Gi: 2Gi
         cpu: 2
         memory: 256Mi
-        intel.com/sriov_vfio_s1u_net: '1'
-        intel.com/sriov_vfio_sgi_net: '1'
+        intel.com/sriov_vfio_access_net: '1'
+        intel.com/sriov_vfio_core_net: '1'
     volumeMounts:
     - name: upf-conf
       mountPath: /conf


### PR DESCRIPTION
This patch fixes the min upf.json needed for deploying latest upf in k8s.
Also, update the interface names from s11 & sgi to access & core

Signed-off-by: Deepak Soma Reddy <depeak.s@intel.com>