### PR TITLE
[SDFAB-914] Get UE IP address for UL PDR from correlated DL PDR

### DIFF
--- a/pfcpiface/parse-far.go
+++ b/pfcpiface/parse-far.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"fmt"
+
 	log "github.com/sirupsen/logrus"
 	"github.com/wmnsk/go-pfcp/ie"
 )
@@ -45,8 +46,8 @@ type far struct {
 }
 
 func (f far) String() string {
-	return fmt.Sprintf("FAR(id=%v, F-SEID=%v, F-SEID IPv4=%v, dstInterface=%v, tunnelType=%v, " +
-		"tunnelIPv4Src=%v, tunnelIPv4Dst=%v, tunnelTEID=%v, tunnelSrcPort=%v, " +
+	return fmt.Sprintf("FAR(id=%v, F-SEID=%v, F-SEID IPv4=%v, dstInterface=%v, tunnelType=%v, "+
+		"tunnelIPv4Src=%v, tunnelIPv4Dst=%v, tunnelTEID=%v, tunnelSrcPort=%v, "+
 		"sendEndMarker=%v, drops=%v, forwards=%v, buffers=%v)", f.farID, f.fseID, f.fseidIP, f.dstIntf,
 		f.tunnelType, f.tunnelIP4Src, f.tunnelIP4Dst, f.tunnelTEID, f.tunnelPort, f.sendEndMarker,
 		f.Drops(), f.Forwards(), f.Buffers())

--- a/pfcpiface/parse-far.go
+++ b/pfcpiface/parse-far.go
@@ -5,8 +5,6 @@ package main
 
 import (
 	"fmt"
-	"strings"
-
 	log "github.com/sirupsen/logrus"
 	"github.com/wmnsk/go-pfcp/ie"
 )
@@ -46,23 +44,12 @@ type far struct {
 	tunnelPort    uint16
 }
 
-// FIXME: refactor it and use fmt.Sprintf()
 func (f far) String() string {
-	b := strings.Builder{}
-	fmt.Fprintf(&b, "\n")
-	fmt.Fprintf(&b, "farID: %v\n", f.farID)
-	fmt.Fprintf(&b, "fseID: %x\n", f.fseID)
-	fmt.Fprintf(&b, "fseIDIP: %v\n", int2ip(f.fseidIP))
-	fmt.Fprintf(&b, "dstIntf: %v\n", f.dstIntf)
-	fmt.Fprintf(&b, "applyAction: %v\n", f.applyAction)
-	fmt.Fprintf(&b, "tunnelType: %v\n", f.tunnelType)
-	fmt.Fprintf(&b, "tunnelIP4Src: %v\n", int2ip(f.tunnelIP4Src))
-	fmt.Fprintf(&b, "tunnelIP4Dst: %v\n", int2ip(f.tunnelIP4Dst))
-	fmt.Fprintf(&b, "tunnelTEID: %x\n", f.tunnelTEID)
-	fmt.Fprintf(&b, "tunnelPort: %v\n", f.tunnelPort)
-	fmt.Fprintf(&b, "sendEndMarker: %v\n", f.sendEndMarker)
-
-	return b.String()
+	return fmt.Sprintf("FAR(id=%v, F-SEID=%v, F-SEID IPv4=%v, dstInterface=%v, tunnelType=%v, " +
+		"tunnelIPv4Src=%v, tunnelIPv4Dst=%v, tunnelTEID=%v, tunnelSrcPort=%v, " +
+		"sendEndMarker=%v, drops=%v, forwards=%v, buffers=%v)", f.farID, f.fseID, f.fseidIP, f.dstIntf,
+		f.tunnelType, f.tunnelIP4Src, f.tunnelIP4Dst, f.tunnelTEID, f.tunnelPort, f.sendEndMarker,
+		f.Drops(), f.Forwards(), f.Buffers())
 }
 
 func (f *far) Drops() bool {

--- a/pfcpiface/parse-pdr.go
+++ b/pfcpiface/parse-pdr.go
@@ -6,9 +6,10 @@ package main
 import (
 	"errors"
 	"fmt"
+	"net"
+
 	log "github.com/sirupsen/logrus"
 	"github.com/wmnsk/go-pfcp/ie"
-	"net"
 )
 
 type pdr struct {
@@ -50,14 +51,22 @@ func needAllocIP(ueIPaddr *ie.UEIPAddressFields) bool {
 }
 
 func (p pdr) String() string {
-	return fmt.Sprintf("PDR(id=%v, F-SEID=%v, srcIface=%v, tunnelIPv4Dst=%v/%x, " +
-		"tunnelTEID=%v/%x, srcIP=%v/%x, dstIP=%v/%x," +
-		"srcPort=%v/%x, dstPort=%v/%x, protocol=%v/%x, precedence=%v, F-SEID IP=%v, " +
+	return fmt.Sprintf("PDR(id=%v, F-SEID=%v, srcIface=%v, tunnelIPv4Dst=%v/%x, "+
+		"tunnelTEID=%v/%x, srcIP=%v/%x, dstIP=%v/%x,"+
+		"srcPort=%v/%x, dstPort=%v/%x, protocol=%v/%x, precedence=%v, F-SEID IP=%v, "+
 		"counterID=%v, farID=%v, qerIDs=%v, needDecap=%v, allocIPFlag=%v)",
 		p.pdrID, p.fseID, p.srcIface, p.tunnelIP4Dst, p.tunnelIP4DstMask,
 		p.tunnelTEID, p.tunnelTEIDMask, p.srcIP, p.srcIPMask, p.dstIP, p.dstIPMask,
 		p.srcPort, p.srcPortMask, p.dstPort, p.dstPortMask, p.proto, p.protoMask, p.precedence,
 		p.fseidIP, p.ctrID, p.farID, p.qerIDList, p.needDecap, p.allocIPFlag)
+}
+
+func (p pdr) IsUplink() bool {
+	return p.srcIface == access
+}
+
+func (p pdr) IsDownlink() bool {
+	return p.srcIface == core
 }
 
 func (p *pdr) parsePDI(seid uint64, pdiIEs []*ie.IE, appPFDs map[string]appPFD, ippool *IPPool) error {

--- a/pfcpiface/parse-pdr.go
+++ b/pfcpiface/parse-pdr.go
@@ -6,11 +6,9 @@ package main
 import (
 	"errors"
 	"fmt"
-	"net"
-	"strings"
-
 	log "github.com/sirupsen/logrus"
 	"github.com/wmnsk/go-pfcp/ie"
+	"net"
 )
 
 type pdr struct {
@@ -52,39 +50,14 @@ func needAllocIP(ueIPaddr *ie.UEIPAddressFields) bool {
 }
 
 func (p pdr) String() string {
-	b := strings.Builder{}
-	fmt.Fprintf(&b, "\n")
-	fmt.Fprintf(&b, "srcIface: %v\n", p.srcIface)
-	fmt.Fprintf(&b, "tunnelIP4Dst: %v\n", int2ip(p.tunnelIP4Dst))
-	fmt.Fprintf(&b, "tunnelTEID: %x\n", p.tunnelTEID)
-	fmt.Fprintf(&b, "tunnelTEIDMask: %x\n", p.tunnelTEIDMask)
-	fmt.Fprintf(&b, "srcIP: %v\n", int2ip(p.srcIP))
-	fmt.Fprintf(&b, "dstIP: %v\n", int2ip(p.dstIP))
-	fmt.Fprintf(&b, "srcPort: %v\n", p.srcPort)
-	fmt.Fprintf(&b, "dstPort: %v\n", p.dstPort)
-	fmt.Fprintf(&b, "proto: %v\n", p.proto)
-	fmt.Fprintf(&b, "srcIfaceMask: %x\n", p.srcIfaceMask)
-	fmt.Fprintf(&b, "tunnelIP4DstMask: %v\n", int2ip(p.tunnelIP4DstMask))
-	fmt.Fprintf(&b, "srcIPMask: %v\n", int2ip(p.srcIPMask))
-	fmt.Fprintf(&b, "dstIPMask: %v\n", int2ip(p.dstIPMask))
-	fmt.Fprintf(&b, "srcPortMask: %x\n", p.srcPortMask)
-	fmt.Fprintf(&b, "dstPortMask: %x\n", p.dstPortMask)
-	fmt.Fprintf(&b, "protoMask: %x\n", p.protoMask)
-	fmt.Fprintf(&b, "precedence: %v\n", p.precedence)
-	fmt.Fprintf(&b, "pdrID: %v\n", p.pdrID)
-	fmt.Fprintf(&b, "fseID: %x\n", p.fseID)
-	fmt.Fprintf(&b, "fseidIP: %v\n", int2ip(p.fseidIP))
-	fmt.Fprintf(&b, "ctrID: %v\n", p.ctrID)
-	fmt.Fprintf(&b, "farID: %v\n", p.farID)
-
-	for _, qer := range p.qerIDList {
-		fmt.Fprintf(&b, "qerID: %v\n", qer)
-	}
-
-	fmt.Fprintf(&b, "needDecap: %v\n", p.needDecap)
-	fmt.Fprintf(&b, "allocIPFlag: %v\n", p.allocIPFlag)
-
-	return b.String()
+	return fmt.Sprintf("PDR(id=%v, F-SEID=%v, srcIface=%v, tunnelIPv4Dst=%v/%x, " +
+		"tunnelTEID=%v/%x, srcIP=%v/%x, dstIP=%v/%x," +
+		"srcPort=%v/%x, dstPort=%v/%x, protocol=%v/%x, precedence=%v, F-SEID IP=%v, " +
+		"counterID=%v, farID=%v, qerIDs=%v, needDecap=%v, allocIPFlag=%v)",
+		p.pdrID, p.fseID, p.srcIface, p.tunnelIP4Dst, p.tunnelIP4DstMask,
+		p.tunnelTEID, p.tunnelTEIDMask, p.srcIP, p.srcIPMask, p.dstIP, p.dstIPMask,
+		p.srcPort, p.srcPortMask, p.dstPort, p.dstPortMask, p.proto, p.protoMask, p.precedence,
+		p.fseidIP, p.ctrID, p.farID, p.qerIDList, p.needDecap, p.allocIPFlag)
 }
 
 func (p *pdr) parsePDI(seid uint64, pdiIEs []*ie.IE, appPFDs map[string]appPFD, ippool *IPPool) error {

--- a/pfcpiface/parse-pdr.go
+++ b/pfcpiface/parse-pdr.go
@@ -51,7 +51,6 @@ func needAllocIP(ueIPaddr *ie.UEIPAddressFields) bool {
 	return true
 }
 
-// Satisfies the fmt.Stringer interface.
 func (p pdr) String() string {
 	b := strings.Builder{}
 	fmt.Fprintf(&b, "\n")

--- a/pfcpiface/parse-qer.go
+++ b/pfcpiface/parse-qer.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"fmt"
+
 	log "github.com/sirupsen/logrus"
 	"github.com/wmnsk/go-pfcp/ie"
 )
@@ -24,7 +25,7 @@ type qer struct {
 }
 
 func (q qer) String() string {
-	return fmt.Sprintf("QER(id=%v, F-SEID=%v, F-SEID IP=%v, QFI=%v, " +
+	return fmt.Sprintf("QER(id=%v, F-SEID=%v, F-SEID IP=%v, QFI=%v, "+
 		"uplinkMBR=%v, downlinkMBR=%v, uplinkGBR=%v, downlinkGBR=%v)",
 		q.qerID, q.fseID, q.fseidIP, q.qfi, q.ulMbr, q.dlMbr, q.ulGbr, q.dlGbr)
 }

--- a/pfcpiface/parse-qer.go
+++ b/pfcpiface/parse-qer.go
@@ -5,8 +5,6 @@ package main
 
 import (
 	"fmt"
-	"strings"
-
 	log "github.com/sirupsen/logrus"
 	"github.com/wmnsk/go-pfcp/ie"
 )
@@ -25,22 +23,10 @@ type qer struct {
 	fseidIP  uint32
 }
 
-// Satisfies the fmt.Stringer interface.
 func (q qer) String() string {
-	b := strings.Builder{}
-	fmt.Fprintf(&b, "\n")
-	fmt.Fprintf(&b, "qerID: %v\n", q.qerID)
-	fmt.Fprintf(&b, "fseID: %x\n", q.fseID)
-	fmt.Fprintf(&b, "qfi: %v\n", q.qfi)
-	fmt.Fprintf(&b, "fseIDIP: %v\n", int2ip(q.fseidIP))
-	fmt.Fprintf(&b, "uplinkStatus: %v\n", q.ulStatus)
-	fmt.Fprintf(&b, "downlinkStatus: %v\n", q.dlStatus)
-	fmt.Fprintf(&b, "uplinkMBR: %v\n", q.ulMbr)
-	fmt.Fprintf(&b, "downlinkMBR: %v\n", q.dlMbr)
-	fmt.Fprintf(&b, "uplinkGBR: %v\n", q.ulGbr)
-	fmt.Fprintf(&b, "downlinkGBR: %v\n", q.dlGbr)
-
-	return b.String()
+	return fmt.Sprintf("QER(id=%v, F-SEID=%v, F-SEID IP=%v, QFI=%v, " +
+		"uplinkMBR=%v, downlinkMBR=%v, uplinkGBR=%v, downlinkGBR=%v)",
+		q.qerID, q.fseID, q.fseidIP, q.qfi, q.ulMbr, q.dlMbr, q.ulGbr, q.dlGbr)
 }
 
 func (q *qer) parseQER(ie1 *ie.IE, seid uint64) error {

--- a/pfcpiface/sessions.go
+++ b/pfcpiface/sessions.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/omec-project/upf-epc/pfcpiface/metrics"
@@ -27,6 +28,10 @@ type PFCPSession struct {
 	notificationFlag notifyFlag
 	metrics          *metrics.Session
 	PacketForwardingRules
+}
+
+func (p PacketForwardingRules) String() string {
+	return fmt.Sprintf("PDRs=%v, FARs=%v, QERs=%v", p.pdrs, p.fars, p.qers)
 }
 
 // NewPFCPSession allocates an session with ID.

--- a/pfcpiface/up4.go
+++ b/pfcpiface/up4.go
@@ -72,6 +72,10 @@ type UP4 struct {
 	// ueAddrToFSEID is used to store UE Address <-> F-SEID mapping,
 	// which is needed to efficiently find F-SEID when we receive a P4 Digest (DDN) for a UE address.
 	ueAddrToFSEID map[uint32]uint64
+	// fseidToUEAddr is used to store F-SEID <-> UE Address mapping,
+	// which is needed to efficiently find UE address for UL PDRs in the PFCP messages.
+	// We need both maps to make lookup efficient, but both maps should always be updated in atomic way.
+	fseidToUEAddr map[uint64]uint32
 
 	reportNotifyChan chan<- uint64
 	endMarkerChan    chan []byte
@@ -268,6 +272,7 @@ func (up4 *UP4) setUpfInfo(u *upf, conf *Conf) {
 	up4.enableEndMarker = conf.EnableEndMarker
 	up4.initTunnelPeerIDs()
 	up4.ueAddrToFSEID = make(map[uint32]uint64)
+	up4.fseidToUEAddr = make(map[uint64]uint32)
 
 	up4.counters = make([]counter, 2)
 	for i := range up4.counters {
@@ -452,7 +457,6 @@ func (up4 *UP4) addOrUpdateGTPTunnelPeer(far far) error {
 
 		tunnelPeerID, err = up4.allocateGTPTunnelPeerID()
 		if err != nil {
-			//log.Error("failed to allocate GTP tunnel peer ID based on FAR: ", err)
 			return err
 		}
 
@@ -507,21 +511,13 @@ func (up4 *UP4) removeGTPTunnelPeer(far far) {
 	up4.releaseAllocatedGTPTunnelPeerID(tunnelPeerID)
 }
 
-func (up4 *UP4) sendMsgToUPF(method upfMsgType, rules PacketForwardingRules, updated PacketForwardingRules) uint8 {
+func (up4 *UP4) sendMsgToUPF(method upfMsgType, all PacketForwardingRules, updated PacketForwardingRules) uint8 {
 	up4Log := log.WithFields(log.Fields{
 		"method-type":   method,
-		"old-rules":     rules,
+		"old-rules":     all,
 		"updated-rules": updated,
 	})
 	up4Log.Debug("Sending PFCP message to UP4..")
-
-	pdrs := rules.pdrs
-	fars := rules.fars
-
-	if method == upfMsgTypeMod {
-		// no need to use updated PDRs as session's PDRs are already updated
-		fars = updated.fars
-	}
 
 	var (
 		methodType p4.Update_Type
@@ -539,26 +535,39 @@ func (up4 *UP4) sendMsgToUPF(method upfMsgType, rules PacketForwardingRules, upd
 	case upfMsgTypeAdd:
 		{
 			methodType = p4.Update_INSERT
-			for i := range pdrs {
+			for i := range updated.pdrs {
 				val, err = getCounterVal(up4, preQosCounterID)
 				if err != nil {
 					log.Println("Counter id alloc failed ", err)
 					return cause
 				}
-				pdrs[i].ctrID = uint32(val)
+				updated.pdrs[i].ctrID = uint32(val)
+			}
+
+			for _, p := range updated.pdrs {
+				up4.insertUeAddrAndFSEIDMappings(p)
 			}
 		}
 	case upfMsgTypeDel:
 		{
 			methodType = p4.Update_DELETE
-			for i := range pdrs {
+			for i := range updated.pdrs {
 				resetCounterVal(up4, preQosCounterID,
-					uint64(pdrs[i].ctrID))
+					uint64(updated.pdrs[i].ctrID))
+			}
+
+			for _, p := range all.pdrs {
+				up4.removeUeAddrAndFSEIDMappings(p)
 			}
 		}
 	case upfMsgTypeMod:
 		{
 			methodType = p4.Update_MODIFY
+
+			// Update PDR IE might modify UE IP <-> F-SEID mappings
+			for _, p := range updated.pdrs {
+				up4.insertUeAddrAndFSEIDMappings(p)
+			}
 		}
 	default:
 		{
@@ -567,7 +576,7 @@ func (up4 *UP4) sendMsgToUPF(method upfMsgType, rules PacketForwardingRules, upd
 		}
 	}
 
-	for _, far := range fars {
+	for _, far := range updated.fars {
 		// downlink FAR that does encapsulation
 		if far.Forwards() && far.dstIntf == ie.DstInterfaceAccess {
 			switch method {
@@ -580,6 +589,7 @@ func (up4 *UP4) sendMsgToUPF(method upfMsgType, rules PacketForwardingRules, upd
 					if err := up4.addOrUpdateGTPTunnelPeer(far); err != nil {
 						up4Log.WithFields(log.Fields{
 							"far": far,
+							"error": err.Error(),
 						}).Error("Failed to add or update GTP tunnel peer")
 					}
 				}
@@ -593,13 +603,13 @@ func (up4 *UP4) sendMsgToUPF(method upfMsgType, rules PacketForwardingRules, upd
 		}
 	}
 
-	for _, pdr := range pdrs {
+	for _, pdr := range updated.pdrs {
 		pdrLog := log.WithFields(log.Fields{
 			"pdr": pdr,
 		})
 		pdrLog.Traceln(pdr)
 
-		far, err := findRelatedFAR(pdr, fars)
+		far, err := findRelatedFAR(pdr, all.fars)
 		if err != nil {
 			pdrLog.Warning("no related FAR for PDR found: ", err)
 			continue
@@ -625,6 +635,16 @@ func (up4 *UP4) sendMsgToUPF(method upfMsgType, rules PacketForwardingRules, upd
 			continue
 		}
 
+		if pdr.srcIface == access {
+			ueAddr, exists := up4.fseidToUEAddr[pdr.fseID]
+			if !exists {
+				// this is only possible if a linked DL PDR was not provided in the same PFCP message
+				log.Error("UE Address not found for uplink PDR, a linked DL PDR was not provided?")
+				return cause
+			}
+			pdr.srcIP = ueAddr
+		}
+
 		// FIXME: get TC from QFI->TC mapping
 		terminationsEntry, err := up4.p4RtTranslator.BuildTerminationsTableEntry(pdr, far, uint8(0))
 		if err != nil {
@@ -640,8 +660,6 @@ func (up4 *UP4) sendMsgToUPF(method upfMsgType, rules PacketForwardingRules, upd
 			log.Error("failed to write table entries to Sessions and Terminations tables: ", err)
 			return cause
 		}
-
-		up4.saveUeAddrToFSEID(pdr)
 	}
 
 	cause = ie.CauseRequestAccepted
@@ -649,18 +667,20 @@ func (up4 *UP4) sendMsgToUPF(method upfMsgType, rules PacketForwardingRules, upd
 	return cause
 }
 
-func (up4 *UP4) saveUeAddrToFSEID(pdr pdr) {
-	var ueAddr uint32
-	if pdr.srcIface == access {
-		ueAddr = pdr.srcIP
-	} else if pdr.srcIface == core {
-		ueAddr = pdr.dstIP
-	} else {
-		// unknown PDR direction
+func (up4 *UP4) insertUeAddrAndFSEIDMappings(pdr pdr) {
+	if pdr.srcIface != core {
 		return
 	}
 
-	if _, exists := up4.ueAddrToFSEID[ueAddr]; !exists {
-		up4.ueAddrToFSEID[ueAddr] = pdr.fseID
+	// update both maps in one shot
+	up4.ueAddrToFSEID[pdr.dstIP], up4.fseidToUEAddr[pdr.fseID] = pdr.fseID, pdr.dstIP
+}
+
+func (up4 *UP4) removeUeAddrAndFSEIDMappings(pdr pdr) {
+	if pdr.srcIface != core {
+		return
 	}
+
+	delete(up4.ueAddrToFSEID, pdr.dstIP)
+	delete(up4.fseidToUEAddr, pdr.fseID)
 }

--- a/pfcpiface/up4.go
+++ b/pfcpiface/up4.go
@@ -528,16 +528,16 @@ func (up4 *UP4) sendMsgToUPF(method upfMsgType, all PacketForwardingRules, updat
 	case upfMsgTypeAdd:
 		{
 			methodType = p4.Update_INSERT
-			for i := range all.pdrs {
+			for i := range updated.pdrs {
 				val, err = getCounterVal(up4, preQosCounterID)
 				if err != nil {
 					log.Println("Counter id alloc failed ", err)
 					return cause
 				}
-				all.pdrs[i].ctrID = uint32(val)
+				updated.pdrs[i].ctrID = uint32(val)
 			}
 
-			for _, p := range all.pdrs {
+			for _, p := range updated.pdrs {
 				up4.updateUEAddrAndFSEIDMappings(p)
 			}
 		}


### PR DESCRIPTION
This PR enables using the latest UP4 pipeline with the current implementation of 4G SD-Core. 

It implements the way to get UE IP address for UL PDR from correlated DL PDR, and introduces the following requirement on the N4 interface: SMF/SPGW-C must always send both DL and UL PDRs associated to the same F-SEID in the PFCP Establishment Request. However, this requirement only exists if UP4 plugin is used. 

This PR extends UP4 object with the `fseidToUEAddr` map that enables efficient way to find a correlated DL PDR for an UL PDR. Such implementation avoids iterating over the entire list of already-installed PDRs to get a correlated DL PDR. 