### PR TITLE
Improve logging of conf at startup

### DIFF
--- a/pfcpiface/main.go
+++ b/pfcpiface/main.go
@@ -184,7 +184,7 @@ func main() {
 		log.SetLevel(level)
 	}
 
-	log.Infoln(conf)
+	log.Infof("%+v", conf)
 
 	if conf.EnableP4rt {
 		fp = &UP4{}


### PR DESCRIPTION
Logging the fields makes the log line actually useful, as one can see which fields have which value without manually matching them to the struct definition.

```
{Mode:sim AccessIface:{IfName:access} CoreIface:{IfName:core} CPIface:{Peers:[] UseFQDN:false NodeID: EnableUeIPAlloc:true UEIPPool:10.250.0.0/29 HTTPPort:8080 Dnn:internet} P4rtcIface:{AccessIP:172.17.0.1/32 P4rtcServer:onos P4rtcPort:51001 UEIP:10.250.0.0/24} EnableP4rt:false EnableFlowMeasure:true SimInfo:{MaxSessions:10 StartUEIP:16.0.0.1 StartENBIP:11.1.1.129 StartAUPFIP:13.1.1.199 N6AppIP:6.6.6.6 N9AppIP:9.9.9.9 StartN3TEID:0x30000000 StartN9TEID:0x90000000} ConnTimeout:0 ReadTimeout:0 EnableNotifyBess:false EnableEndMarker:false NotifySockAddr: EndMarkerSockAddr: LogLevel:trace QciQosConfig:[{QCI:0 CBS:50000 PBS:50000 EBS:50000 BurstDurationMs:10 SchedulingPriority:7}] SliceMeterConfig:{N6RateBps:50000000000 N6BurstBytes:625000 N3RateBps:50000000000 N3BurstBytes:625000} MaxReqRetries:5 RespTimeout:2s EnableHBTimer:false HeartBeatInterval:}
```