### PR TITLE
Partially revert `b5898ed`

### DIFF
--- a/pfcpiface/bess.go
+++ b/pfcpiface/bess.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/binary"
 	"flag"
+	"math"
 	"net"
 	"strconv"
 	"time"
@@ -676,7 +677,7 @@ func (b *bess) addPDR(ctx context.Context, done chan<- bool, p pdr) {
 
 		f := &pb.WildcardMatchCommandAddArg{
 			Gate:     uint64(p.needDecap),
-			Priority: int64(p.precedence),
+			Priority: int64(math.MaxUint32 - p.precedence),
 			Values: []*pb.FieldData{
 				intEnc(uint64(p.srcIface)),     /* src_iface */
 				intEnc(uint64(p.tunnelIP4Dst)), /* tunnel_ipv4_dst */


### PR DESCRIPTION
We mistakenly removed the priority inversion in #384. This PR adds it back in so we're spec compliant.