### PR TITLE
Revert license headers format for auto-generated Go pb files

### DIFF
--- a/pfcpiface/bess_pb/bess_msg.pb.go
+++ b/pfcpiface/bess_pb/bess_msg.pb.go
@@ -1,5 +1,5 @@
-// Copyright 2016-2017, Nefeli Networks, Inc.
-// Copyright 2017, The Regents of the University of California.
+// Copyright (c) 2016-2017, Nefeli Networks, Inc.
+// Copyright (c) 2017, The Regents of the University of California.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/pfcpiface/bess_pb/error.pb.go
+++ b/pfcpiface/bess_pb/error.pb.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017, Nefeli Networks, Inc.
+// Copyright (c) 2016-2017, Nefeli Networks, Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/pfcpiface/bess_pb/module_msg.pb.go
+++ b/pfcpiface/bess_pb/module_msg.pb.go
@@ -1,5 +1,5 @@
-// Copyright 2016-2017, Nefeli Networks, Inc.
-// Copyright 2017, The Regents of the University of California.
+// Copyright (c) 2016-2017, Nefeli Networks, Inc.
+// Copyright (c) 2017, The Regents of the University of California.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/pfcpiface/bess_pb/ports/port_msg.pb.go
+++ b/pfcpiface/bess_pb/ports/port_msg.pb.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017, Nefeli Networks, Inc.
+// Copyright (c) 2016-2017, Nefeli Networks, Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/pfcpiface/bess_pb/service.pb.go
+++ b/pfcpiface/bess_pb/service.pb.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017, Nefeli Networks, Inc.
+// Copyright (c) 2016-2017, Nefeli Networks, Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/pfcpiface/bess_pb/util_msg.pb.go
+++ b/pfcpiface/bess_pb/util_msg.pb.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2017, Nefeli Networks, Inc.
+// Copyright (c) 2016-2017, Nefeli Networks, Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Protoc emits the verbatim license header from the the `.proto` source file. In this case they use the `(c)` form, as seen here: https://github.com/NetSys/bess/blob/master/protobuf/bess_msg.proto#L1-L2
This PR is a follow up to #404, where we attempted to use a uniform style.
Reuse will recognize and accept both.