### PR TITLE
Fix HB timer

### DIFF
--- a/pfcpiface/messages-conn.go
+++ b/pfcpiface/messages-conn.go
@@ -59,8 +59,10 @@ func (pConn *PFCPConn) handleHeartbeatRequest(msg message.Message) (message.Mess
 		return nil, errUnmarshal(errMsgUnexpectedType)
 	}
 
-	// reset heartbeat expiry timer
-	pConn.hbReset <- struct{}{}
+	if pConn.upf.enableHBTimer {
+		// reset heartbeat expiry timer
+		pConn.hbReset <- struct{}{}
+	}
 
 	// TODO: Check and update remote recovery timestamp
 

--- a/pfcpiface/messages-conn.go
+++ b/pfcpiface/messages-conn.go
@@ -61,7 +61,14 @@ func (pConn *PFCPConn) handleHeartbeatRequest(msg message.Message) (message.Mess
 
 	if pConn.upf.enableHBTimer {
 		// reset heartbeat expiry timer
-		pConn.hbReset <- struct{}{}
+		// non-blocking write to channel
+		select {
+		case pConn.hbReset <- struct{}{}:
+			// timer reset
+		default:
+			// channel full, log warning and ignore
+			log.Warn("failed to reset heartbeat timer")
+		}
 	}
 
 	// TODO: Check and update remote recovery timestamp


### PR DESCRIPTION
If HB timer is disabled (by default), PFCP Agent keeps pushing to the `hbReset` channel, but there is no receiver on the other end of the channel. Therefore, if the channel buffer becomes full (100 heartbeats), the sending Go routine gets stuck. 

Fix the bug by pushing to `hbReset` only if HB timer is enabled, and by only issuing non-blocking writes.