### PR TITLE
Add `PortRange` type and support PDR port ranges in BESS-upf

### DIFF
--- a/pfcpiface/bess.go
+++ b/pfcpiface/bess.go
@@ -712,7 +712,7 @@ func (b *bess) addPDR(ctx context.Context, done chan<- bool, p pdr) {
 		}
 
 		// Translate port ranges into ternary rule(s) and insert them one-by-one.
-		portRules, err := CreatePortFilterCartesianProduct(p.appFilter.srcPortFilter, p.appFilter.dstPortFilter)
+		portRules, err := CreatePortRangeCartesianProduct(p.appFilter.srcPortRange, p.appFilter.dstPortRange)
 		if err != nil {
 			log.Errorln(err)
 			return
@@ -773,7 +773,7 @@ func (b *bess) delPDR(ctx context.Context, done chan<- bool, p pdr) {
 		)
 
 		// Translate port ranges into ternary rule(s) and insert them one-by-one.
-		portRules, err := CreatePortFilterCartesianProduct(p.appFilter.srcPortFilter, p.appFilter.dstPortFilter)
+		portRules, err := CreatePortRangeCartesianProduct(p.appFilter.srcPortRange, p.appFilter.dstPortRange)
 		if err != nil {
 			log.Errorln(err)
 			return

--- a/pfcpiface/bess.go
+++ b/pfcpiface/bess.go
@@ -712,12 +712,12 @@ func (b *bess) addPDR(ctx context.Context, done chan<- bool, p pdr) {
 		}
 
 		// Translate port ranges into ternary rule(s) and insert them one-by-one.
-		portRules, err := convertPortFiltersToTernary(p.appFilter.srcPortFilter, p.appFilter.dstPortFilter)
+		portRules, err := CreatePortFilterCartesianProduct(p.appFilter.srcPortFilter, p.appFilter.dstPortFilter)
 		if err != nil {
 			log.Errorln(err)
 			return
 		}
-		log.Warnln("PDR rules", portRules)
+		log.Tracef("PDR rules %+v", portRules)
 
 		for _, r := range portRules {
 			f := &pb.WildcardMatchCommandAddArg{
@@ -772,7 +772,7 @@ func (b *bess) delPDR(ctx context.Context, done chan<- bool, p pdr) {
 		)
 
 		// Translate port ranges into ternary rule(s) and insert them one-by-one.
-		portRules, err := convertPortFiltersToTernary(p.appFilter.srcPortFilter, p.appFilter.dstPortFilter)
+		portRules, err := CreatePortFilterCartesianProduct(p.appFilter.srcPortFilter, p.appFilter.dstPortFilter)
 		if err != nil {
 			log.Errorln(err)
 			return

--- a/pfcpiface/bess.go
+++ b/pfcpiface/bess.go
@@ -717,6 +717,7 @@ func (b *bess) addPDR(ctx context.Context, done chan<- bool, p pdr) {
 			log.Errorln(err)
 			return
 		}
+
 		log.Tracef("PDR rules %+v", portRules)
 
 		for _, r := range portRules {
@@ -807,6 +808,7 @@ func (b *bess) delPDR(ctx context.Context, done chan<- bool, p pdr) {
 				log.Errorln("Error marshalling the rule", f, err)
 				return
 			}
+
 			b.processPDR(ctx, any, upfMsgTypeDel)
 		}
 		done <- true

--- a/pfcpiface/bess.go
+++ b/pfcpiface/bess.go
@@ -711,45 +711,55 @@ func (b *bess) addPDR(ctx context.Context, done chan<- bool, p pdr) {
 			break
 		}
 
-		f := &pb.WildcardMatchCommandAddArg{
-			Gate:     uint64(p.needDecap),
-			Priority: int64(math.MaxUint32 - p.precedence),
-			Values: []*pb.FieldData{
-				intEnc(uint64(p.srcIface)),          /* src_iface */
-				intEnc(uint64(p.tunnelIP4Dst)),      /* tunnel_ipv4_dst */
-				intEnc(uint64(p.tunnelTEID)),        /* enb_teid */
-				intEnc(uint64(p.appFilter.srcIP)),   /* ueaddr ip*/
-				intEnc(uint64(p.appFilter.dstIP)),   /* inet ip */
-				intEnc(uint64(p.appFilter.srcPort)), /* ue port */
-				intEnc(uint64(p.appFilter.dstPort)), /* inet port */
-				intEnc(uint64(p.appFilter.proto)),   /* proto id */
-			},
-			Masks: []*pb.FieldData{
-				intEnc(uint64(p.srcIfaceMask)),          /* src_iface-mask */
-				intEnc(uint64(p.tunnelIP4DstMask)),      /* tunnel_ipv4_dst-mask */
-				intEnc(uint64(p.tunnelTEIDMask)),        /* enb_teid-mask */
-				intEnc(uint64(p.appFilter.srcIPMask)),   /* ueaddr ip-mask */
-				intEnc(uint64(p.appFilter.dstIPMask)),   /* inet ip-mask */
-				intEnc(uint64(p.appFilter.srcPortMask)), /* ue port-mask */
-				intEnc(uint64(p.appFilter.dstPortMask)), /* inet port-mask */
-				intEnc(uint64(p.appFilter.protoMask)),   /* proto id-mask */
-			},
-			Valuesv: []*pb.FieldData{
-				intEnc(uint64(p.pdrID)), /* pdr-id */
-				intEnc(p.fseID),         /* fseid */
-				intEnc(uint64(p.ctrID)), /* ctr_id */
-				intEnc(uint64(qerID)),   /* qer_id */
-				intEnc(uint64(p.farID)), /* far_id */
-			},
-		}
-
-		any, err = anypb.New(f)
+		// Translate port ranges into ternary rule(s) and insert them one-by-one.
+		portRules, err := convertPortFiltersToTernary(p.appFilter.srcPortFilter, p.appFilter.dstPortFilter)
 		if err != nil {
-			log.Println("Error marshalling the rule", f, err)
+			log.Errorln(err)
 			return
 		}
+		log.Warnln("PDR rules", portRules)
 
-		b.processPDR(ctx, any, upfMsgTypeAdd)
+		for _, r := range portRules {
+			f := &pb.WildcardMatchCommandAddArg{
+				Gate:     uint64(p.needDecap),
+				Priority: int64(math.MaxUint32 - p.precedence),
+				Values: []*pb.FieldData{
+					intEnc(uint64(p.srcIface)),        /* src_iface */
+					intEnc(uint64(p.tunnelIP4Dst)),    /* tunnel_ipv4_dst */
+					intEnc(uint64(p.tunnelTEID)),      /* enb_teid */
+					intEnc(uint64(p.appFilter.srcIP)), /* ueaddr ip*/
+					intEnc(uint64(p.appFilter.dstIP)), /* inet ip */
+					intEnc(uint64(r.srcPort)),         /* ue port */
+					intEnc(uint64(r.dstPort)),         /* inet port */
+					intEnc(uint64(p.appFilter.proto)), /* proto id */
+				},
+				Masks: []*pb.FieldData{
+					intEnc(uint64(p.srcIfaceMask)),        /* src_iface-mask */
+					intEnc(uint64(p.tunnelIP4DstMask)),    /* tunnel_ipv4_dst-mask */
+					intEnc(uint64(p.tunnelTEIDMask)),      /* enb_teid-mask */
+					intEnc(uint64(p.appFilter.srcIPMask)), /* ueaddr ip-mask */
+					intEnc(uint64(p.appFilter.dstIPMask)), /* inet ip-mask */
+					intEnc(uint64(r.srcMask)),             /* ue port-mask */
+					intEnc(uint64(r.dstMask)),             /* inet port-mask */
+					intEnc(uint64(p.appFilter.protoMask)), /* proto id-mask */
+				},
+				Valuesv: []*pb.FieldData{
+					intEnc(uint64(p.pdrID)), /* pdr-id */
+					intEnc(p.fseID),         /* fseid */
+					intEnc(uint64(p.ctrID)), /* ctr_id */
+					intEnc(uint64(qerID)),   /* qer_id */
+					intEnc(uint64(p.farID)), /* far_id */
+				},
+			}
+
+			any, err = anypb.New(f)
+			if err != nil {
+				log.Println("Error marshalling the rule", f, err)
+				return
+			}
+
+			b.processPDR(ctx, any, upfMsgTypeAdd)
+		}
 		done <- true
 	}()
 }
@@ -761,36 +771,44 @@ func (b *bess) delPDR(ctx context.Context, done chan<- bool, p pdr) {
 			err error
 		)
 
-		f := &pb.WildcardMatchCommandDeleteArg{
-			Values: []*pb.FieldData{
-				intEnc(uint64(p.srcIface)),          /* src_iface */
-				intEnc(uint64(p.tunnelIP4Dst)),      /* tunnel_ipv4_dst */
-				intEnc(uint64(p.tunnelTEID)),        /* enb_teid */
-				intEnc(uint64(p.appFilter.srcIP)),   /* ueaddr ip*/
-				intEnc(uint64(p.appFilter.dstIP)),   /* inet ip */
-				intEnc(uint64(p.appFilter.srcPort)), /* ue port */
-				intEnc(uint64(p.appFilter.dstPort)), /* inet port */
-				intEnc(uint64(p.appFilter.proto)),   /* proto id */
-			},
-			Masks: []*pb.FieldData{
-				intEnc(uint64(p.srcIfaceMask)),          /* src_iface-mask */
-				intEnc(uint64(p.tunnelIP4DstMask)),      /* tunnel_ipv4_dst-mask */
-				intEnc(uint64(p.tunnelTEIDMask)),        /* enb_teid-mask */
-				intEnc(uint64(p.appFilter.srcIPMask)),   /* ueaddr ip-mask */
-				intEnc(uint64(p.appFilter.dstIPMask)),   /* inet ip-mask */
-				intEnc(uint64(p.appFilter.srcPortMask)), /* ue port-mask */
-				intEnc(uint64(p.appFilter.dstPortMask)), /* inet port-mask */
-				intEnc(uint64(p.appFilter.protoMask)),   /* proto id-mask */
-			},
-		}
-
-		any, err = anypb.New(f)
+		// Translate port ranges into ternary rule(s) and insert them one-by-one.
+		portRules, err := convertPortFiltersToTernary(p.appFilter.srcPortFilter, p.appFilter.dstPortFilter)
 		if err != nil {
-			log.Errorln("Error marshalling the rule", f, err)
+			log.Errorln(err)
 			return
 		}
 
-		b.processPDR(ctx, any, upfMsgTypeDel)
+		for _, r := range portRules {
+			f := &pb.WildcardMatchCommandDeleteArg{
+				Values: []*pb.FieldData{
+					intEnc(uint64(p.srcIface)),        /* src_iface */
+					intEnc(uint64(p.tunnelIP4Dst)),    /* tunnel_ipv4_dst */
+					intEnc(uint64(p.tunnelTEID)),      /* enb_teid */
+					intEnc(uint64(p.appFilter.srcIP)), /* ueaddr ip*/
+					intEnc(uint64(p.appFilter.dstIP)), /* inet ip */
+					intEnc(uint64(r.srcPort)),         /* ue port */
+					intEnc(uint64(r.dstPort)),         /* inet port */
+					intEnc(uint64(p.appFilter.proto)), /* proto id */
+				},
+				Masks: []*pb.FieldData{
+					intEnc(uint64(p.srcIfaceMask)),        /* src_iface-mask */
+					intEnc(uint64(p.tunnelIP4DstMask)),    /* tunnel_ipv4_dst-mask */
+					intEnc(uint64(p.tunnelTEIDMask)),      /* enb_teid-mask */
+					intEnc(uint64(p.appFilter.srcIPMask)), /* ueaddr ip-mask */
+					intEnc(uint64(p.appFilter.dstIPMask)), /* inet ip-mask */
+					intEnc(uint64(r.srcMask)),             /* ue port-mask */
+					intEnc(uint64(r.dstMask)),             /* inet port-mask */
+					intEnc(uint64(p.appFilter.protoMask)), /* proto id-mask */
+				},
+			}
+
+			any, err = anypb.New(f)
+			if err != nil {
+				log.Errorln("Error marshalling the rule", f, err)
+				return
+			}
+			b.processPDR(ctx, any, upfMsgTypeDel)
+		}
 		done <- true
 	}()
 }

--- a/pfcpiface/p4rt_translator.go
+++ b/pfcpiface/p4rt_translator.go
@@ -539,7 +539,7 @@ func (t *P4rtTranslator) BuildApplicationsTableEntry(pdr pdr, internalAppID uint
 	}
 
 	if !appPort.isWildcardMatch() {
-		if err := t.withRangeMatchField(entry, FieldAppL4Port, appPort, appPort); err != nil {
+		if err := t.withRangeMatchField(entry, FieldAppL4Port, appPort.portLow, appPort.portHigh); err != nil {
 			return nil, err
 		}
 	}

--- a/pfcpiface/p4rt_translator.go
+++ b/pfcpiface/p4rt_translator.go
@@ -523,10 +523,10 @@ func (t *P4rtTranslator) BuildApplicationsTableEntry(pdr pdr, internalAppID uint
 
 	if pdr.srcIface == access {
 		appIP, appIPMask = pdr.appFilter.dstIP, pdr.appFilter.dstIPMask
-		appPort = pdr.appFilter.dstPortFilter
+		appPort = pdr.appFilter.dstPortRange
 	} else if pdr.srcIface == core {
 		appIP, appIPMask = pdr.appFilter.srcIP, pdr.appFilter.srcIPMask
-		appPort = pdr.appFilter.srcPortFilter
+		appPort = pdr.appFilter.srcPortRange
 	}
 
 	appProto, appProtoMask := pdr.appFilter.proto, pdr.appFilter.protoMask

--- a/pfcpiface/p4rt_translator.go
+++ b/pfcpiface/p4rt_translator.go
@@ -518,15 +518,15 @@ func (t *P4rtTranslator) BuildApplicationsTableEntry(pdr pdr, internalAppID uint
 
 	var (
 		appIP, appIPMask uint32 = 0, 0
-		appPort          uint16 = 0
+		appPort          portFilter
 	)
 
 	if pdr.srcIface == access {
 		appIP, appIPMask = pdr.appFilter.dstIP, pdr.appFilter.dstIPMask
-		appPort = pdr.appFilter.dstPort
+		appPort = pdr.appFilter.dstPortFilter
 	} else if pdr.srcIface == core {
 		appIP, appIPMask = pdr.appFilter.srcIP, pdr.appFilter.srcIPMask
-		appPort = pdr.appFilter.srcPort
+		appPort = pdr.appFilter.srcPortFilter
 	}
 
 	appProto, appProtoMask := pdr.appFilter.proto, pdr.appFilter.protoMask
@@ -538,7 +538,7 @@ func (t *P4rtTranslator) BuildApplicationsTableEntry(pdr pdr, internalAppID uint
 		}
 	}
 
-	if appPort != 0 {
+	if !appPort.isWildcardMatch() {
 		if err := t.withRangeMatchField(entry, FieldAppL4Port, appPort, appPort); err != nil {
 			return nil, err
 		}

--- a/pfcpiface/p4rt_translator.go
+++ b/pfcpiface/p4rt_translator.go
@@ -518,7 +518,7 @@ func (t *P4rtTranslator) BuildApplicationsTableEntry(pdr pdr, internalAppID uint
 
 	var (
 		appIP, appIPMask uint32 = 0, 0
-		appPort          portFilter
+		appPort          portRange
 	)
 
 	if pdr.srcIface == access {
@@ -539,7 +539,7 @@ func (t *P4rtTranslator) BuildApplicationsTableEntry(pdr pdr, internalAppID uint
 	}
 
 	if !appPort.isWildcardMatch() {
-		if err := t.withRangeMatchField(entry, FieldAppL4Port, appPort.portLow, appPort.portHigh); err != nil {
+		if err := t.withRangeMatchField(entry, FieldAppL4Port, appPort.low, appPort.high); err != nil {
 			return nil, err
 		}
 	}

--- a/pfcpiface/parse-pdr.go
+++ b/pfcpiface/parse-pdr.go
@@ -46,7 +46,7 @@ func newRangeMatchPortFilter(low, high uint16) portFilter {
 }
 
 func (pr portFilter) String() string {
-	return fmt.Sprintf("{ %v - %v }", pr.portLow, pr.portHigh)
+	return fmt.Sprintf("{%v-%v}", pr.portLow, pr.portHigh)
 }
 
 func (pr portFilter) isWildcardMatch() bool {

--- a/pfcpiface/parse-pdr.go
+++ b/pfcpiface/parse-pdr.go
@@ -168,7 +168,7 @@ type portFilterTernaryCrossProduct struct {
 // Converts two port ranges into a list of ternary rules covering the same range.
 func convertPortFiltersToTernary(src, dst portFilter) ([]portFilterTernaryCrossProduct, error) {
 	// A single range rule can result in multiple ternary ones. To cover the same range of packets,
-	// we need to create the cross product of src and dst rules. For now, we only allow one true
+	// we need to create the Cartesian product of src and dst rules. For now, we only allow one true
 	// range match to keep the complexity in check.
 	if src.isRangeMatch() && dst.isRangeMatch() {
 		return nil, ErrInvalidArgumentWithReason("convertPortFiltersToTernary",

--- a/pfcpiface/parse-pdr.go
+++ b/pfcpiface/parse-pdr.go
@@ -21,6 +21,8 @@ type portFilter struct {
 	portHigh uint16
 }
 
+// newWildcardPortFilter returns a portFilter that matches on every possible port, i.e., implements
+// no filtering.
 func newWildcardPortFilter() portFilter {
 	return portFilter{
 		portLow:  0,
@@ -28,6 +30,7 @@ func newWildcardPortFilter() portFilter {
 	}
 }
 
+// newExactMatchPortFilter returns a portFilter that matches on exactly the given port.
 func newExactMatchPortFilter(port uint16) portFilter {
 	return portFilter{
 		portLow:  port,
@@ -35,6 +38,9 @@ func newExactMatchPortFilter(port uint16) portFilter {
 	}
 }
 
+// newRangeMatchPortFilter returns a portFilter that matches on the given range [low, high].
+// low must be smaller than high. Creating exact and wildcard matches with this function is
+// possible, but use of the dedicated functions is encouraged.
 func newRangeMatchPortFilter(low, high uint16) portFilter {
 	if low > high {
 		return portFilter{}
@@ -42,6 +48,18 @@ func newRangeMatchPortFilter(low, high uint16) portFilter {
 	return portFilter{
 		portLow:  low,
 		portHigh: high,
+	}
+}
+
+// newTernaryMatchPortFilter returns a portFilter that matches on the given port and mask. Only
+// trivial mask are supported.
+func newTernaryMatchPortFilter(port, mask uint16) (portFilter, error) {
+	if mask == 0 {
+		return newWildcardPortFilter(), nil
+	} else if mask == math.MaxUint16 {
+		return newExactMatchPortFilter(port), nil
+	} else {
+		return portFilter{}, ErrInvalidArgument("newTernaryMatchPortFilter", mask)
 	}
 }
 

--- a/pfcpiface/parse-pdr.go
+++ b/pfcpiface/parse-pdr.go
@@ -14,7 +14,8 @@ import (
 	"github.com/wmnsk/go-pfcp/ie"
 )
 
-// portFilter encapsulates a L4 port range as seen in SDF.
+// portFilter encapsulates a L4 port range as seen in PDRs. A zero value portFilter represents
+// a wildcard match, but use of the dedicated new*PortFilter() functions is encouraged.
 type portFilter struct {
 	portLow  uint16
 	portHigh uint16

--- a/pfcpiface/parse-pdr.go
+++ b/pfcpiface/parse-pdr.go
@@ -67,6 +67,16 @@ func (pr portFilter) String() string {
 	return fmt.Sprintf("{%v-%v}", pr.portLow, pr.portHigh)
 }
 
+// Width returns the number of ports covered by this portFilter.
+func (pr portFilter) Width() uint16 {
+	// Need to handle the zero value.
+	if pr.isWildcardMatch() {
+		return math.MaxUint16
+	} else {
+		return pr.portHigh - pr.portLow + 1
+	}
+}
+
 func (pr portFilter) isWildcardMatch() bool {
 	return pr.portLow == 0 && pr.portHigh == math.MaxUint16 ||
 		pr.portLow == 0 && pr.portHigh == 0

--- a/pfcpiface/parse-pdr.go
+++ b/pfcpiface/parse-pdr.go
@@ -498,8 +498,9 @@ func (p *pdr) parsePDI(seid uint64, pdiIEs []*ie.IE, appPFDs map[string]appPFD, 
 				p.appFilter.srcIPMask = ipMask2int(ipf.dst.IPNet.Mask)
 				p.appFilter.dstIP = ip2int(ipf.src.IPNet.IP)
 				p.appFilter.dstIPMask = ipMask2int(ipf.src.IPNet.Mask)
-				p.appFilter.dstPortFilter = ipf.dst.ports
-				p.appFilter.srcPortFilter = ipf.src.ports
+				// Ports are flipped for access PDRs
+				p.appFilter.dstPortFilter = ipf.src.ports
+				p.appFilter.srcPortFilter = ipf.dst.ports
 
 				// FIXME: temporary workaround for SDF Filter,
 				//  remove once we meet spec compliance

--- a/pfcpiface/parse-pdr_test.go
+++ b/pfcpiface/parse-pdr_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2022 Open Networking Foundation
+
 package main
 
 import (

--- a/pfcpiface/parse-pdr_test.go
+++ b/pfcpiface/parse-pdr_test.go
@@ -17,12 +17,12 @@ func Test_CreatePortFilterCartesianProduct(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    []portFilterTernaryCartesianProduct
+		want    []portRangeTernaryCartesianProduct
 		wantErr bool
 	}{
 		{name: "exact ranges",
 			args: args{src: newExactMatchPortFilter(5000), dst: newExactMatchPortFilter(80)},
-			want: []portFilterTernaryCartesianProduct{{
+			want: []portRangeTernaryCartesianProduct{{
 				srcPort: 5000,
 				srcMask: math.MaxUint16,
 				dstPort: 80,
@@ -31,7 +31,7 @@ func Test_CreatePortFilterCartesianProduct(t *testing.T) {
 			wantErr: false},
 		{name: "wildcard dst range",
 			args: args{src: newExactMatchPortFilter(10), dst: newWildcardPortFilter()},
-			want: []portFilterTernaryCartesianProduct{{
+			want: []portRangeTernaryCartesianProduct{{
 				srcPort: 10,
 				srcMask: math.MaxUint16,
 				dstPort: 0,
@@ -40,7 +40,7 @@ func Test_CreatePortFilterCartesianProduct(t *testing.T) {
 			wantErr: false},
 		{name: "true range src range",
 			args: args{src: newRangeMatchPortFilter(1, 3), dst: newExactMatchPortFilter(80)},
-			want: []portFilterTernaryCartesianProduct{
+			want: []portRangeTernaryCartesianProduct{
 				{
 					srcPort: 0x1,
 					srcMask: 0xffff,
@@ -106,7 +106,7 @@ func Test_newWildcardPortFilter(t *testing.T) {
 	}
 }
 
-func Test_portFilter_String(t *testing.T) {
+func Test_portRange_String(t *testing.T) {
 	tests := []struct {
 		name string
 		pr   portRange
@@ -126,7 +126,7 @@ func Test_portFilter_String(t *testing.T) {
 	}
 }
 
-func Test_portFilter_isExactMatch(t *testing.T) {
+func Test_portRange_isExactMatch(t *testing.T) {
 	tests := []struct {
 		name string
 		pr   portRange
@@ -146,7 +146,7 @@ func Test_portFilter_isExactMatch(t *testing.T) {
 	}
 }
 
-func Test_portFilter_isRangeMatch(t *testing.T) {
+func Test_portRange_isRangeMatch(t *testing.T) {
 	tests := []struct {
 		name string
 		pr   portRange
@@ -166,7 +166,7 @@ func Test_portFilter_isRangeMatch(t *testing.T) {
 	}
 }
 
-func Test_portFilter_isWildcardMatch(t *testing.T) {
+func Test_portRange_isWildcardMatch(t *testing.T) {
 	tests := []struct {
 		name string
 		pr   portRange
@@ -191,7 +191,7 @@ func Test_portFilter_isWildcardMatch(t *testing.T) {
 }
 
 // Perform a ternary match of value against rules.
-func matchesTernary(value uint16, rules []portFilterTernaryRule) bool {
+func matchesTernary(value uint16, rules []portRangeTernaryRule) bool {
 	for _, r := range rules {
 		if (value & r.mask) == r.port {
 			return true
@@ -201,20 +201,20 @@ func matchesTernary(value uint16, rules []portFilterTernaryRule) bool {
 	return false
 }
 
-func Test_portFilter_asComplexTernaryMatches(t *testing.T) {
+func Test_portRange_asComplexTernaryMatches(t *testing.T) {
 	tests := []struct {
 		name     string
 		pr       portRange
 		strategy RangeConversionStrategy
 		wantErr  bool
-		want     []portFilterTernaryRule
+		want     []portRangeTernaryRule
 	}{
 		{name: "Exact match port range",
 			pr: portRange{
 				low:  8888,
 				high: 8888,
 			},
-			want: []portFilterTernaryRule{
+			want: []portRangeTernaryRule{
 				{port: 8888, mask: 0xffff},
 			},
 			wantErr: false},
@@ -223,7 +223,7 @@ func Test_portFilter_asComplexTernaryMatches(t *testing.T) {
 				low:  0,
 				high: math.MaxUint16,
 			},
-			want: []portFilterTernaryRule{
+			want: []portRangeTernaryRule{
 				{port: 0, mask: 0},
 			},
 			wantErr: false},
@@ -232,7 +232,7 @@ func Test_portFilter_asComplexTernaryMatches(t *testing.T) {
 				low:  0b0, // 0
 				high: 0b1, // 1
 			},
-			//want: []portFilterTernaryRule{
+			//want: []portRangeTernaryRule{
 			//	{port: 0b0, mask: 0xfffe},
 			//},
 			wantErr: false},
@@ -241,7 +241,7 @@ func Test_portFilter_asComplexTernaryMatches(t *testing.T) {
 				low:  0b01, // 1
 				high: 0b10, // 2
 			},
-			//want: []portFilterTernaryRule{
+			//want: []portRangeTernaryRule{
 			//	{port: 0b01, mask: 0xffff},
 			//	{port: 0b10, mask: 0xffff},
 			//},
@@ -252,7 +252,7 @@ func Test_portFilter_asComplexTernaryMatches(t *testing.T) {
 				high: 0x01ff, // 511
 			},
 			strategy: Ternary,
-			//want: []portFilterTernaryRule{
+			//want: []portRangeTernaryRule{
 			//	{port: 0x0100, mask: 0xff00},
 			//},
 			wantErr: false},
@@ -261,7 +261,7 @@ func Test_portFilter_asComplexTernaryMatches(t *testing.T) {
 				low:  0b01, // 1
 				high: 0b11, // 3
 			},
-			//want: []portFilterTernaryRule{
+			//want: []portRangeTernaryRule{
 			//	{port: 0b01, mask: 0xffff},
 			//	{port: 0b10, mask: 0xfffe},
 			//},
@@ -320,7 +320,7 @@ func Test_portFilter_asComplexTernaryMatches(t *testing.T) {
 	}
 }
 
-func Test_portFilter_asTrivialTernaryMatch(t *testing.T) {
+func Test_portRange_asTrivialTernaryMatch(t *testing.T) {
 	tests := []struct {
 		name     string
 		pr       portRange
@@ -362,7 +362,7 @@ func Test_portFilter_asTrivialTernaryMatch(t *testing.T) {
 	}
 }
 
-func Test_portFilter_Width(t *testing.T) {
+func Test_portRange_Width(t *testing.T) {
 	tests := []struct {
 		name string
 		pr   portRange

--- a/pfcpiface/parse-pdr_test.go
+++ b/pfcpiface/parse-pdr_test.go
@@ -1,0 +1,364 @@
+package main
+
+import (
+	"math"
+	"reflect"
+	"testing"
+)
+
+func Test_convertPortFiltersToTernary(t *testing.T) {
+	type args struct {
+		src portFilter
+		dst portFilter
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []portFilterTernaryCrossProduct
+		wantErr bool
+	}{
+		{name: "exact ranges",
+			args: args{src: newExactMatchPortFilter(5000), dst: newExactMatchPortFilter(80)},
+			want: []portFilterTernaryCrossProduct{{
+				srcPort: 5000,
+				srcMask: math.MaxUint16,
+				dstPort: 80,
+				dstMask: math.MaxUint16,
+			}},
+			wantErr: false},
+		{name: "wildcard dst range",
+			args: args{src: newExactMatchPortFilter(10), dst: newWildcardPortFilter()},
+			want: []portFilterTernaryCrossProduct{{
+				srcPort: 10,
+				srcMask: math.MaxUint16,
+				dstPort: 0,
+				dstMask: 0,
+			}},
+			wantErr: false},
+		{name: "true range src range",
+			args: args{src: newRangeMatchPortFilter(1, 3), dst: newExactMatchPortFilter(80)},
+			want: []portFilterTernaryCrossProduct{
+				{
+					srcPort: 0x1,
+					srcMask: 0xffff,
+					dstPort: 80,
+					dstMask: math.MaxUint16,
+				},
+				{
+					srcPort: 0x2,
+					srcMask: 0xfffe,
+					dstPort: 80,
+					dstMask: math.MaxUint16,
+				}},
+			wantErr: false},
+		{name: "invalid double range",
+			args:    args{src: newRangeMatchPortFilter(10, 20), dst: newRangeMatchPortFilter(80, 85)},
+			want:    nil,
+			wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(
+			tt.name, func(t *testing.T) {
+				got, err := convertPortFiltersToTernary(tt.args.src, tt.args.dst)
+				if (err != nil) != tt.wantErr {
+					t.Errorf("convertPortFiltersToTernary() error = %v, wantErr %v", err, tt.wantErr)
+					return
+				}
+				if !reflect.DeepEqual(got, tt.want) {
+					t.Errorf("convertPortFiltersToTernary() got = %v, want %v", got, tt.want)
+				}
+			},
+		)
+	}
+}
+
+func Test_newWildcardPortFilter(t *testing.T) {
+	tests := []struct {
+		name string
+		want portFilter
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(
+			tt.name, func(t *testing.T) {
+				if got := newWildcardPortFilter(); !reflect.DeepEqual(got, tt.want) {
+					t.Errorf("newWildcardPortFilter() = %v, want %v", got, tt.want)
+				}
+			},
+		)
+	}
+}
+
+func Test_portFilter_String(t *testing.T) {
+	type fields struct {
+		PortLow  uint16
+		PortHigh uint16
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(
+			tt.name, func(t *testing.T) {
+				pr := portFilter{
+					portLow:  tt.fields.PortLow,
+					portHigh: tt.fields.PortHigh,
+				}
+				if got := pr.String(); got != tt.want {
+					t.Errorf("String() = %v, want %v", got, tt.want)
+				}
+			},
+		)
+	}
+}
+
+func Test_portFilter_isExactMatch(t *testing.T) {
+	type fields struct {
+		PortLow  uint16
+		PortHigh uint16
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(
+			tt.name, func(t *testing.T) {
+				pr := portFilter{
+					portLow:  tt.fields.PortLow,
+					portHigh: tt.fields.PortHigh,
+				}
+				if got := pr.isExactMatch(); got != tt.want {
+					t.Errorf("isExactMatch() = %v, want %v", got, tt.want)
+				}
+			},
+		)
+	}
+}
+
+func Test_portFilter_isRangeMatch(t *testing.T) {
+	type fields struct {
+		PortLow  uint16
+		PortHigh uint16
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(
+			tt.name, func(t *testing.T) {
+				pr := portFilter{
+					portLow:  tt.fields.PortLow,
+					portHigh: tt.fields.PortHigh,
+				}
+				if got := pr.isRangeMatch(); got != tt.want {
+					t.Errorf("isRangeMatch() = %v, want %v", got, tt.want)
+				}
+			},
+		)
+	}
+}
+
+func Test_portFilter_isWildcardMatch(t *testing.T) {
+	type fields struct {
+		PortLow  uint16
+		PortHigh uint16
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   bool
+	}{
+		// TODO: Add test cases.
+		{name: "foo", fields: fields{
+			PortLow:  0,
+			PortHigh: 0,
+		}, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(
+			tt.name, func(t *testing.T) {
+				pr := portFilter{
+					portLow:  tt.fields.PortLow,
+					portHigh: tt.fields.PortHigh,
+				}
+				if got := pr.isWildcardMatch(); got != tt.want {
+					t.Errorf("isWildcardMatch() = %v, want %v", got, tt.want)
+				}
+			},
+		)
+	}
+}
+
+// Perform a ternary match of value against rules.
+func matchesTernary(value uint16, rules []portFilterTernaryRule) bool {
+	for _, r := range rules {
+		if (value & r.mask) == r.port {
+			return true
+		}
+	}
+	return false
+}
+
+func Test_portFilter_asComplexTernaryMatches(t *testing.T) {
+	tests := []struct {
+		name    string
+		pr      portFilter
+		wantErr bool
+	}{
+		{name: "Exact match port range",
+			pr: portFilter{
+				portLow:  8888,
+				portHigh: 8888,
+			},
+			//want: []portFilterTernaryRule{
+			//	{port: 8888, mask: 0xffff},
+			//},
+			wantErr: false},
+		{name: "wildcard port range",
+			pr: portFilter{
+				portLow:  0,
+				portHigh: math.MaxUint16,
+			},
+			wantErr: false},
+		{name: "Simplest port range",
+			pr: portFilter{
+				portLow:  0b0, // 0
+				portHigh: 0b1, // 1
+			},
+			//want: []portFilterTernaryRule{
+			//	{port: 0b0, mask: 0xfffe},
+			//},
+			wantErr: false},
+		{name: "Simplest port range2",
+			pr: portFilter{
+				portLow:  0b01, // 1
+				portHigh: 0b10, // 2
+			},
+			//want: []portFilterTernaryRule{
+			//	{port: 0b01, mask: 0xffff},
+			//	{port: 0b10, mask: 0xffff},
+			//},
+			wantErr: false},
+		{name: "Trivial ternary port range",
+			pr: portFilter{
+				portLow:  0x0100, // 256
+				portHigh: 0x01ff, // 511
+			},
+			//want: []portFilterTernaryRule{
+			//	{port: 0x0100, mask: 0xff00},
+			//},
+			wantErr: false},
+		{name: "one to three range",
+			pr: portFilter{
+				portLow:  0b01, // 1
+				portHigh: 0b11, // 3
+			},
+			//want: []portFilterTernaryRule{
+			//	{port: 0b01, mask: 0xffff},
+			//	{port: 0b10, mask: 0xfffe},
+			//},
+			wantErr: false},
+		{name: "True port range",
+			pr: portFilter{
+				portLow:  0b00010, //  2
+				portHigh: 0b11101, // 29
+			},
+			wantErr: false},
+		{name: "low port filter",
+			pr: portFilter{
+				portLow:  0,
+				portHigh: 1023,
+			},
+			wantErr: false},
+		{name: "some app filter",
+			pr: portFilter{
+				portLow:  8080,
+				portHigh: 8084,
+			},
+			wantErr: false},
+	}
+	for _, tt := range tests {
+		t.Run(
+			tt.name, func(t *testing.T) {
+				pr := portFilter{
+					portLow:  tt.pr.portLow,
+					portHigh: tt.pr.portHigh,
+				}
+				got, err := pr.asComplexTernaryMatches()
+				if (err != nil) != tt.wantErr {
+					t.Errorf("asComplexTernaryMatches() error = %v, wantErr %v", err, tt.wantErr)
+					return
+				}
+				//if !reflect.DeepEqual(got, tt.want) {
+				//	t.Errorf("asComplexTernaryMatches() got = %v, want %v", got, tt.want)
+				//}
+				// Do exhaustive test over entire value range.
+				for port := 0; port <= math.MaxUint16; port++ {
+					expectMatch := port >= int(tt.pr.portLow) && port <= int(tt.pr.portHigh)
+					if matchesTernary(uint16(port), got) != expectMatch {
+						mod := " "
+						if !expectMatch {
+							mod = " not "
+						}
+						t.Errorf("Expected port %v to%vmatch against rules %v from range %+v", port, mod, got, tt.pr)
+					}
+				}
+			},
+		)
+	}
+}
+
+func Test_portFilter_asTrivialTernaryMatch(t *testing.T) {
+	tests := []struct {
+		name     string
+		pr       portFilter
+		wantPort uint16
+		wantMask uint16
+		wantErr  bool
+	}{
+		{name: "Wildcard range", pr: portFilter{
+			portLow:  0,
+			portHigh: 0,
+		}, wantPort: 0, wantMask: 0, wantErr: false},
+		{name: "Exact match range", pr: portFilter{
+			portLow:  100,
+			portHigh: 100,
+		}, wantPort: 100, wantMask: 0xffff, wantErr: false},
+		{name: "True range match fail", pr: portFilter{
+			portLow:  100,
+			portHigh: 200,
+		}, wantPort: 0, wantMask: 0, wantErr: true},
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(
+			tt.name, func(t *testing.T) {
+				got, err := tt.pr.asTrivialTernaryMatch()
+				if (err != nil) != tt.wantErr {
+					t.Errorf("asTrivialTernaryMatch() error = %v, wantErr %v", err, tt.wantErr)
+					return
+				}
+
+				if got.port != tt.wantPort {
+					t.Errorf("asTrivialTernaryMatch() got = %v, want %v", got.port, tt.wantPort)
+				}
+				if got.mask != tt.wantMask {
+					t.Errorf("asTrivialTernaryMatch() got = %v, want %v", got.mask, tt.wantMask)
+				}
+			},
+		)
+	}
+}

--- a/pfcpiface/parse-pdr_test.go
+++ b/pfcpiface/parse-pdr_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/stretchr/testify/assert"
 	"math"
 	"reflect"
 	"testing"
@@ -70,6 +71,12 @@ func Test_convertPortFiltersToTernary(t *testing.T) {
 			},
 		)
 	}
+}
+
+func Test_defaultPortFilter(t *testing.T) {
+	t.Run("default constructed is wildcard", func(t *testing.T) {
+		assert.True(t, portFilter{}.isWildcardMatch(), "default portFilter is wildcard")
+	})
 }
 
 func Test_newWildcardPortFilter(t *testing.T) {

--- a/pfcpiface/parse-pdr_test.go
+++ b/pfcpiface/parse-pdr_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_CreatePortFilterCartesianProduct(t *testing.T) {
+func Test_CreatePortRangeCartesianProduct(t *testing.T) {
 	type args struct {
 		src portRange
 		dst portRange
@@ -21,7 +21,7 @@ func Test_CreatePortFilterCartesianProduct(t *testing.T) {
 		wantErr bool
 	}{
 		{name: "exact ranges",
-			args: args{src: newExactMatchPortFilter(5000), dst: newExactMatchPortFilter(80)},
+			args: args{src: newExactMatchPortRange(5000), dst: newExactMatchPortRange(80)},
 			want: []portRangeTernaryCartesianProduct{{
 				srcPort: 5000,
 				srcMask: math.MaxUint16,
@@ -30,7 +30,7 @@ func Test_CreatePortFilterCartesianProduct(t *testing.T) {
 			}},
 			wantErr: false},
 		{name: "wildcard dst range",
-			args: args{src: newExactMatchPortFilter(10), dst: newWildcardPortFilter()},
+			args: args{src: newExactMatchPortRange(10), dst: newWildcardPortRange()},
 			want: []portRangeTernaryCartesianProduct{{
 				srcPort: 10,
 				srcMask: math.MaxUint16,
@@ -39,7 +39,7 @@ func Test_CreatePortFilterCartesianProduct(t *testing.T) {
 			}},
 			wantErr: false},
 		{name: "true range src range",
-			args: args{src: newRangeMatchPortFilter(1, 3), dst: newExactMatchPortFilter(80)},
+			args: args{src: newRangeMatchPortRange(1, 3), dst: newExactMatchPortRange(80)},
 			want: []portRangeTernaryCartesianProduct{
 				{
 					srcPort: 0x1,
@@ -61,7 +61,7 @@ func Test_CreatePortFilterCartesianProduct(t *testing.T) {
 				}},
 			wantErr: false},
 		{name: "invalid double range",
-			args:    args{src: newRangeMatchPortFilter(10, 20), dst: newRangeMatchPortFilter(80, 85)},
+			args:    args{src: newRangeMatchPortRange(10, 20), dst: newRangeMatchPortRange(80, 85)},
 			want:    nil,
 			wantErr: true},
 	}
@@ -69,26 +69,26 @@ func Test_CreatePortFilterCartesianProduct(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(
 			tt.name, func(t *testing.T) {
-				got, err := CreatePortFilterCartesianProduct(tt.args.src, tt.args.dst)
+				got, err := CreatePortRangeCartesianProduct(tt.args.src, tt.args.dst)
 				if (err != nil) != tt.wantErr {
-					t.Errorf("CreatePortFilterCartesianProduct() error = %v, wantErr %v", err, tt.wantErr)
+					t.Errorf("CreatePortRangeCartesianProduct() error = %v, wantErr %v", err, tt.wantErr)
 					return
 				}
 				if !reflect.DeepEqual(got, tt.want) {
-					t.Errorf("CreatePortFilterCartesianProduct() got = %v, want %v", got, tt.want)
+					t.Errorf("CreatePortRangeCartesianProduct() got = %v, want %v", got, tt.want)
 				}
 			},
 		)
 	}
 }
 
-func Test_defaultPortFilter(t *testing.T) {
+func Test_defaultPortRange(t *testing.T) {
 	t.Run("default constructed is wildcard", func(t *testing.T) {
 		assert.True(t, portRange{}.isWildcardMatch(), "default portRange is wildcard")
 	})
 }
 
-func Test_newWildcardPortFilter(t *testing.T) {
+func Test_newWildcardPortRange(t *testing.T) {
 	tests := []struct {
 		name string
 		want portRange
@@ -98,8 +98,8 @@ func Test_newWildcardPortFilter(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(
 			tt.name, func(t *testing.T) {
-				if got := newWildcardPortFilter(); !reflect.DeepEqual(got, tt.want) {
-					t.Errorf("newWildcardPortFilter() = %v, want %v", got, tt.want)
+				if got := newWildcardPortRange(); !reflect.DeepEqual(got, tt.want) {
+					t.Errorf("newWildcardPortRange() = %v, want %v", got, tt.want)
 				}
 			},
 		)
@@ -368,11 +368,11 @@ func Test_portRange_Width(t *testing.T) {
 		pr   portRange
 		want uint16
 	}{
-		{name: "wildcard", pr: newWildcardPortFilter(), want: math.MaxUint16},
+		{name: "wildcard", pr: newWildcardPortRange(), want: math.MaxUint16},
 		{name: "zero value", pr: portRange{}, want: math.MaxUint16},
-		{name: "exact match", pr: newExactMatchPortFilter(100), want: 1},
-		{name: "range match", pr: newRangeMatchPortFilter(10, 12), want: 3},
-		{name: "range single match", pr: newRangeMatchPortFilter(1000, 1000), want: 1},
+		{name: "exact match", pr: newExactMatchPortRange(100), want: 1},
+		{name: "range match", pr: newRangeMatchPortRange(10, 12), want: 3},
+		{name: "range single match", pr: newRangeMatchPortRange(1000, 1000), want: 1},
 	}
 	for _, tt := range tests {
 		t.Run(

--- a/pfcpiface/parse-pdr_test.go
+++ b/pfcpiface/parse-pdr_test.go
@@ -288,13 +288,19 @@ func Test_portFilter_asComplexTernaryMatches(t *testing.T) {
 				portHigh: 0b11101, // 29
 			},
 			wantErr: false},
+		{name: "Worst case port range",
+			pr: portFilter{
+				portLow:  1,
+				portHigh: 65534,
+			},
+			wantErr: false},
 		{name: "low port filter",
 			pr: portFilter{
 				portLow:  0,
 				portHigh: 1023,
 			},
 			wantErr: false},
-		{name: "some app filter",
+		{name: "some small app filter",
 			pr: portFilter{
 				portLow:  8080,
 				portHigh: 8084,
@@ -368,6 +374,29 @@ func Test_portFilter_asTrivialTernaryMatch(t *testing.T) {
 				}
 				if got.mask != tt.wantMask {
 					t.Errorf("asTrivialTernaryMatch() got = %v, want %v", got.mask, tt.wantMask)
+				}
+			},
+		)
+	}
+}
+
+func Test_portFilter_Width(t *testing.T) {
+	tests := []struct {
+		name string
+		pr   portFilter
+		want uint16
+	}{
+		{name: "wildcard", pr: newWildcardPortFilter(), want: math.MaxUint16},
+		{name: "zero value", pr: portFilter{}, want: math.MaxUint16},
+		{name: "exact match", pr: newExactMatchPortFilter(100), want: 1},
+		{name: "range match", pr: newRangeMatchPortFilter(10, 12), want: 3},
+		{name: "range single match", pr: newRangeMatchPortFilter(1000, 1000), want: 1},
+	}
+	for _, tt := range tests {
+		t.Run(
+			tt.name, func(t *testing.T) {
+				if got := tt.pr.Width(); got != tt.want {
+					t.Errorf("Width() = %v, want %v", got, tt.want)
 				}
 			},
 		)

--- a/pfcpiface/parse-pdr_test.go
+++ b/pfcpiface/parse-pdr_test.go
@@ -10,8 +10,8 @@ import (
 
 func Test_CreatePortFilterCartesianProduct(t *testing.T) {
 	type args struct {
-		src portFilter
-		dst portFilter
+		src portRange
+		dst portRange
 	}
 
 	tests := []struct {
@@ -84,14 +84,14 @@ func Test_CreatePortFilterCartesianProduct(t *testing.T) {
 
 func Test_defaultPortFilter(t *testing.T) {
 	t.Run("default constructed is wildcard", func(t *testing.T) {
-		assert.True(t, portFilter{}.isWildcardMatch(), "default portFilter is wildcard")
+		assert.True(t, portRange{}.isWildcardMatch(), "default portRange is wildcard")
 	})
 }
 
 func Test_newWildcardPortFilter(t *testing.T) {
 	tests := []struct {
 		name string
-		want portFilter
+		want portRange
 	}{
 		// TODO: Add test cases.
 	}
@@ -108,9 +108,9 @@ func Test_newWildcardPortFilter(t *testing.T) {
 
 func Test_portFilter_String(t *testing.T) {
 	tests := []struct {
-		name   string
-		fields portFilter
-		want   string
+		name string
+		pr   portRange
+		want string
 	}{
 		// TODO: Add test cases.
 	}
@@ -118,11 +118,7 @@ func Test_portFilter_String(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(
 			tt.name, func(t *testing.T) {
-				pr := portFilter{
-					portLow:  tt.fields.portLow,
-					portHigh: tt.fields.portHigh,
-				}
-				if got := pr.String(); got != tt.want {
+				if got := tt.pr.String(); got != tt.want {
 					t.Errorf("String() = %v, want %v", got, tt.want)
 				}
 			},
@@ -132,9 +128,9 @@ func Test_portFilter_String(t *testing.T) {
 
 func Test_portFilter_isExactMatch(t *testing.T) {
 	tests := []struct {
-		name   string
-		fields portFilter
-		want   bool
+		name string
+		pr   portRange
+		want bool
 	}{
 		// TODO: Add test cases.
 	}
@@ -142,11 +138,7 @@ func Test_portFilter_isExactMatch(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(
 			tt.name, func(t *testing.T) {
-				pr := portFilter{
-					portLow:  tt.fields.portLow,
-					portHigh: tt.fields.portHigh,
-				}
-				if got := pr.isExactMatch(); got != tt.want {
+				if got := tt.pr.isExactMatch(); got != tt.want {
 					t.Errorf("isExactMatch() = %v, want %v", got, tt.want)
 				}
 			},
@@ -156,9 +148,9 @@ func Test_portFilter_isExactMatch(t *testing.T) {
 
 func Test_portFilter_isRangeMatch(t *testing.T) {
 	tests := []struct {
-		name   string
-		fields portFilter
-		want   bool
+		name string
+		pr   portRange
+		want bool
 	}{
 		// TODO: Add test cases.
 	}
@@ -166,11 +158,7 @@ func Test_portFilter_isRangeMatch(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(
 			tt.name, func(t *testing.T) {
-				pr := portFilter{
-					portLow:  tt.fields.portLow,
-					portHigh: tt.fields.portHigh,
-				}
-				if got := pr.isRangeMatch(); got != tt.want {
+				if got := tt.pr.isRangeMatch(); got != tt.want {
 					t.Errorf("isRangeMatch() = %v, want %v", got, tt.want)
 				}
 			},
@@ -180,25 +168,21 @@ func Test_portFilter_isRangeMatch(t *testing.T) {
 
 func Test_portFilter_isWildcardMatch(t *testing.T) {
 	tests := []struct {
-		name   string
-		fields portFilter
-		want   bool
+		name string
+		pr   portRange
+		want bool
 	}{
 		// TODO: Add test cases.
-		{name: "foo", fields: portFilter{
-			portLow:  0,
-			portHigh: 0,
+		{name: "foo", pr: portRange{
+			low:  0,
+			high: 0,
 		}, want: true},
 	}
 
 	for _, tt := range tests {
 		t.Run(
 			tt.name, func(t *testing.T) {
-				pr := portFilter{
-					portLow:  tt.fields.portLow,
-					portHigh: tt.fields.portHigh,
-				}
-				if got := pr.isWildcardMatch(); got != tt.want {
+				if got := tt.pr.isWildcardMatch(); got != tt.want {
 					t.Errorf("isWildcardMatch() = %v, want %v", got, tt.want)
 				}
 			},
@@ -220,42 +204,42 @@ func matchesTernary(value uint16, rules []portFilterTernaryRule) bool {
 func Test_portFilter_asComplexTernaryMatches(t *testing.T) {
 	tests := []struct {
 		name     string
-		pr       portFilter
+		pr       portRange
 		strategy RangeConversionStrategy
 		wantErr  bool
 		want     []portFilterTernaryRule
 	}{
 		{name: "Exact match port range",
-			pr: portFilter{
-				portLow:  8888,
-				portHigh: 8888,
+			pr: portRange{
+				low:  8888,
+				high: 8888,
 			},
 			want: []portFilterTernaryRule{
 				{port: 8888, mask: 0xffff},
 			},
 			wantErr: false},
 		{name: "wildcard port range",
-			pr: portFilter{
-				portLow:  0,
-				portHigh: math.MaxUint16,
+			pr: portRange{
+				low:  0,
+				high: math.MaxUint16,
 			},
 			want: []portFilterTernaryRule{
 				{port: 0, mask: 0},
 			},
 			wantErr: false},
 		{name: "Simplest port range",
-			pr: portFilter{
-				portLow:  0b0, // 0
-				portHigh: 0b1, // 1
+			pr: portRange{
+				low:  0b0, // 0
+				high: 0b1, // 1
 			},
 			//want: []portFilterTernaryRule{
 			//	{port: 0b0, mask: 0xfffe},
 			//},
 			wantErr: false},
 		{name: "Simplest port range2",
-			pr: portFilter{
-				portLow:  0b01, // 1
-				portHigh: 0b10, // 2
+			pr: portRange{
+				low:  0b01, // 1
+				high: 0b10, // 2
 			},
 			//want: []portFilterTernaryRule{
 			//	{port: 0b01, mask: 0xffff},
@@ -263,9 +247,9 @@ func Test_portFilter_asComplexTernaryMatches(t *testing.T) {
 			//},
 			wantErr: false},
 		{name: "Trivial ternary port range",
-			pr: portFilter{
-				portLow:  0x0100, // 256
-				portHigh: 0x01ff, // 511
+			pr: portRange{
+				low:  0x0100, // 256
+				high: 0x01ff, // 511
 			},
 			strategy: Ternary,
 			//want: []portFilterTernaryRule{
@@ -273,9 +257,9 @@ func Test_portFilter_asComplexTernaryMatches(t *testing.T) {
 			//},
 			wantErr: false},
 		{name: "one to three range",
-			pr: portFilter{
-				portLow:  0b01, // 1
-				portHigh: 0b11, // 3
+			pr: portRange{
+				low:  0b01, // 1
+				high: 0b11, // 3
 			},
 			//want: []portFilterTernaryRule{
 			//	{port: 0b01, mask: 0xffff},
@@ -283,40 +267,36 @@ func Test_portFilter_asComplexTernaryMatches(t *testing.T) {
 			//},
 			wantErr: false},
 		{name: "True port range",
-			pr: portFilter{
-				portLow:  0b00010, //  2
-				portHigh: 0b11101, // 29
+			pr: portRange{
+				low:  0b00010, //  2
+				high: 0b11101, // 29
 			},
 			wantErr: false},
 		{name: "Worst case port range",
-			pr: portFilter{
-				portLow:  1,
-				portHigh: 65534,
+			pr: portRange{
+				low:  1,
+				high: 65534,
 			},
 			strategy: Ternary,
 			wantErr:  false},
 		{name: "low port filter",
-			pr: portFilter{
-				portLow:  0,
-				portHigh: 1023,
+			pr: portRange{
+				low:  0,
+				high: 1023,
 			},
 			strategy: Ternary,
 			wantErr:  false},
 		{name: "some small app filter",
-			pr: portFilter{
-				portLow:  8080,
-				portHigh: 8084,
+			pr: portRange{
+				low:  8080,
+				high: 8084,
 			},
 			wantErr: false},
 	}
 	for _, tt := range tests {
 		t.Run(
 			tt.name, func(t *testing.T) {
-				pr := portFilter{
-					portLow:  tt.pr.portLow,
-					portHigh: tt.pr.portHigh,
-				}
-				got, err := pr.asComplexTernaryMatches(tt.strategy)
+				got, err := tt.pr.asComplexTernaryMatches(tt.strategy)
 				if (err != nil) != tt.wantErr {
 					t.Errorf("asComplexTernaryMatches() error = %v, wantErr %v", err, tt.wantErr)
 					return
@@ -326,7 +306,7 @@ func Test_portFilter_asComplexTernaryMatches(t *testing.T) {
 				}
 				// Do exhaustive test over entire value range.
 				for port := 0; port <= math.MaxUint16; port++ {
-					expectMatch := port >= int(tt.pr.portLow) && port <= int(tt.pr.portHigh)
+					expectMatch := port >= int(tt.pr.low) && port <= int(tt.pr.high)
 					if matchesTernary(uint16(port), got) != expectMatch {
 						mod := " "
 						if !expectMatch {
@@ -343,22 +323,22 @@ func Test_portFilter_asComplexTernaryMatches(t *testing.T) {
 func Test_portFilter_asTrivialTernaryMatch(t *testing.T) {
 	tests := []struct {
 		name     string
-		pr       portFilter
+		pr       portRange
 		wantPort uint16
 		wantMask uint16
 		wantErr  bool
 	}{
-		{name: "Wildcard range", pr: portFilter{
-			portLow:  0,
-			portHigh: 0,
+		{name: "Wildcard range", pr: portRange{
+			low:  0,
+			high: 0,
 		}, wantPort: 0, wantMask: 0, wantErr: false},
-		{name: "Exact match range", pr: portFilter{
-			portLow:  100,
-			portHigh: 100,
+		{name: "Exact match range", pr: portRange{
+			low:  100,
+			high: 100,
 		}, wantPort: 100, wantMask: 0xffff, wantErr: false},
-		{name: "True range match fail", pr: portFilter{
-			portLow:  100,
-			portHigh: 200,
+		{name: "True range match fail", pr: portRange{
+			low:  100,
+			high: 200,
 		}, wantPort: 0, wantMask: 0, wantErr: true},
 		// TODO: Add test cases.
 	}
@@ -385,11 +365,11 @@ func Test_portFilter_asTrivialTernaryMatch(t *testing.T) {
 func Test_portFilter_Width(t *testing.T) {
 	tests := []struct {
 		name string
-		pr   portFilter
+		pr   portRange
 		want uint16
 	}{
 		{name: "wildcard", pr: newWildcardPortFilter(), want: math.MaxUint16},
-		{name: "zero value", pr: portFilter{}, want: math.MaxUint16},
+		{name: "zero value", pr: portRange{}, want: math.MaxUint16},
 		{name: "exact match", pr: newExactMatchPortFilter(100), want: 1},
 		{name: "range match", pr: newRangeMatchPortFilter(10, 12), want: 3},
 		{name: "range single match", pr: newRangeMatchPortFilter(1000, 1000), want: 1},

--- a/pfcpiface/parse-pdr_test.go
+++ b/pfcpiface/parse-pdr_test.go
@@ -47,7 +47,13 @@ func Test_convertPortFiltersToTernary(t *testing.T) {
 				},
 				{
 					srcPort: 0x2,
-					srcMask: 0xfffe,
+					srcMask: 0xffff,
+					dstPort: 80,
+					dstMask: math.MaxUint16,
+				},
+				{
+					srcPort: 0x3,
+					srcMask: 0xffff,
 					dstPort: 80,
 					dstMask: math.MaxUint16,
 				}},
@@ -314,7 +320,7 @@ func Test_portFilter_asComplexTernaryMatches(t *testing.T) {
 					portLow:  tt.pr.portLow,
 					portHigh: tt.pr.portHigh,
 				}
-				got, err := pr.asComplexTernaryMatches()
+				got, err := pr.asComplexTernaryMatches(Exact)
 				if (err != nil) != tt.wantErr {
 					t.Errorf("asComplexTernaryMatches() error = %v, wantErr %v", err, tt.wantErr)
 					return

--- a/pfcpiface/parse-pdr_test.go
+++ b/pfcpiface/parse-pdr_test.go
@@ -1,10 +1,11 @@
 package main
 
 import (
-	"github.com/stretchr/testify/assert"
 	"math"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_CreatePortFilterCartesianProduct(t *testing.T) {
@@ -12,6 +13,7 @@ func Test_CreatePortFilterCartesianProduct(t *testing.T) {
 		src portFilter
 		dst portFilter
 	}
+
 	tests := []struct {
 		name    string
 		args    args
@@ -63,6 +65,7 @@ func Test_CreatePortFilterCartesianProduct(t *testing.T) {
 			want:    nil,
 			wantErr: true},
 	}
+
 	for _, tt := range tests {
 		t.Run(
 			tt.name, func(t *testing.T) {
@@ -104,23 +107,20 @@ func Test_newWildcardPortFilter(t *testing.T) {
 }
 
 func Test_portFilter_String(t *testing.T) {
-	type fields struct {
-		PortLow  uint16
-		PortHigh uint16
-	}
 	tests := []struct {
 		name   string
-		fields fields
+		fields portFilter
 		want   string
 	}{
 		// TODO: Add test cases.
 	}
+
 	for _, tt := range tests {
 		t.Run(
 			tt.name, func(t *testing.T) {
 				pr := portFilter{
-					portLow:  tt.fields.PortLow,
-					portHigh: tt.fields.PortHigh,
+					portLow:  tt.fields.portLow,
+					portHigh: tt.fields.portHigh,
 				}
 				if got := pr.String(); got != tt.want {
 					t.Errorf("String() = %v, want %v", got, tt.want)
@@ -131,23 +131,20 @@ func Test_portFilter_String(t *testing.T) {
 }
 
 func Test_portFilter_isExactMatch(t *testing.T) {
-	type fields struct {
-		PortLow  uint16
-		PortHigh uint16
-	}
 	tests := []struct {
 		name   string
-		fields fields
+		fields portFilter
 		want   bool
 	}{
 		// TODO: Add test cases.
 	}
+
 	for _, tt := range tests {
 		t.Run(
 			tt.name, func(t *testing.T) {
 				pr := portFilter{
-					portLow:  tt.fields.PortLow,
-					portHigh: tt.fields.PortHigh,
+					portLow:  tt.fields.portLow,
+					portHigh: tt.fields.portHigh,
 				}
 				if got := pr.isExactMatch(); got != tt.want {
 					t.Errorf("isExactMatch() = %v, want %v", got, tt.want)
@@ -158,23 +155,20 @@ func Test_portFilter_isExactMatch(t *testing.T) {
 }
 
 func Test_portFilter_isRangeMatch(t *testing.T) {
-	type fields struct {
-		PortLow  uint16
-		PortHigh uint16
-	}
 	tests := []struct {
 		name   string
-		fields fields
+		fields portFilter
 		want   bool
 	}{
 		// TODO: Add test cases.
 	}
+
 	for _, tt := range tests {
 		t.Run(
 			tt.name, func(t *testing.T) {
 				pr := portFilter{
-					portLow:  tt.fields.PortLow,
-					portHigh: tt.fields.PortHigh,
+					portLow:  tt.fields.portLow,
+					portHigh: tt.fields.portHigh,
 				}
 				if got := pr.isRangeMatch(); got != tt.want {
 					t.Errorf("isRangeMatch() = %v, want %v", got, tt.want)
@@ -185,27 +179,24 @@ func Test_portFilter_isRangeMatch(t *testing.T) {
 }
 
 func Test_portFilter_isWildcardMatch(t *testing.T) {
-	type fields struct {
-		PortLow  uint16
-		PortHigh uint16
-	}
 	tests := []struct {
 		name   string
-		fields fields
+		fields portFilter
 		want   bool
 	}{
 		// TODO: Add test cases.
-		{name: "foo", fields: fields{
-			PortLow:  0,
-			PortHigh: 0,
+		{name: "foo", fields: portFilter{
+			portLow:  0,
+			portHigh: 0,
 		}, want: true},
 	}
+
 	for _, tt := range tests {
 		t.Run(
 			tt.name, func(t *testing.T) {
 				pr := portFilter{
-					portLow:  tt.fields.PortLow,
-					portHigh: tt.fields.PortHigh,
+					portLow:  tt.fields.portLow,
+					portHigh: tt.fields.portHigh,
 				}
 				if got := pr.isWildcardMatch(); got != tt.want {
 					t.Errorf("isWildcardMatch() = %v, want %v", got, tt.want)
@@ -222,6 +213,7 @@ func matchesTernary(value uint16, rules []portFilterTernaryRule) bool {
 			return true
 		}
 	}
+
 	return false
 }
 

--- a/pfcpiface/parse-sdf.go
+++ b/pfcpiface/parse-sdf.go
@@ -71,7 +71,7 @@ func (ep *endpoint) parsePort(port string) error {
 		return ErrInvalidArgumentWithReason("port", port, "invalid port range")
 	}
 
-	ep.ports = newRangeMatchPortFilter(uint16(low), uint16(high))
+	ep.ports = newRangeMatchPortRange(uint16(low), uint16(high))
 
 	return nil
 }
@@ -84,8 +84,8 @@ type ipFilterRule struct {
 
 func newIpFilterRule() *ipFilterRule {
 	return &ipFilterRule{
-		src: endpoint{ports: newWildcardPortFilter()},
-		dst: endpoint{ports: newWildcardPortFilter()},
+		src: endpoint{ports: newWildcardPortRange()},
+		dst: endpoint{ports: newWildcardPortRange()},
 	}
 }
 

--- a/pfcpiface/parse-sdf.go
+++ b/pfcpiface/parse-sdf.go
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 Intel Corporation
+// Copyright 2022 Open Networking Foundation
 
 package main
 
@@ -21,7 +22,7 @@ var errBadFilterDesc = errors.New("unsupported Filter Description format")
 
 type endpoint struct {
 	IPNet *net.IPNet
-	Port  uint16
+	ports portFilter
 }
 
 func (ep *endpoint) parseNet(ipnet string) error {
@@ -66,12 +67,11 @@ func (ep *endpoint) parsePort(port string) error {
 		return err
 	}
 
-	// TODO: support port ranges
-	if low != high {
-		return ErrInvalidArgumentWithReason("port", port, "port ranges are not supported yet")
+	if low > high {
+		return ErrInvalidArgumentWithReason("port", port, "invalid port range")
 	}
 
-	ep.Port = uint16(low)
+	ep.ports = newRangeMatchPortFilter(uint16(low), uint16(high))
 
 	return nil
 }
@@ -82,10 +82,17 @@ type ipFilterRule struct {
 	src, dst          endpoint
 }
 
+func newIpFilterRule() *ipFilterRule {
+	return &ipFilterRule{
+		src: endpoint{ports: newWildcardPortFilter()},
+		dst: endpoint{ports: newWildcardPortFilter()},
+	}
+}
+
 func (ipf *ipFilterRule) String() string {
 	return fmt.Sprintf("FlowDescription{action=%v, direction=%v, proto=%v, "+
 		"srcIP=%v, srcPort=%v, dstIP=%v, dstPort=%v}",
-		ipf.action, ipf.direction, ipf.proto, ipf.src.IPNet, ipf.src.Port, ipf.dst.IPNet, ipf.dst.Port)
+		ipf.action, ipf.direction, ipf.proto, ipf.src.IPNet, ipf.src.ports, ipf.dst.IPNet, ipf.dst.ports)
 }
 
 // "permit out ip from any to assigned"
@@ -106,7 +113,7 @@ func parseFlowDesc(flowDesc, ueIP string) (*ipFilterRule, error) {
 	})
 	parseLog.Debug("Parsing flow description")
 
-	ipf := &ipFilterRule{}
+	ipf := newIpFilterRule()
 
 	fields := strings.Fields(flowDesc)
 

--- a/pfcpiface/parse-sdf.go
+++ b/pfcpiface/parse-sdf.go
@@ -22,7 +22,7 @@ var errBadFilterDesc = errors.New("unsupported Filter Description format")
 
 type endpoint struct {
 	IPNet *net.IPNet
-	ports portFilter
+	ports portRange
 }
 
 func (ep *endpoint) parseNet(ipnet string) error {

--- a/pfcpiface/up4.go
+++ b/pfcpiface/up4.go
@@ -573,7 +573,7 @@ func (up4 *UP4) allocateInternalApplicationID(app application) (uint8, error) {
 func (up4 *UP4) releaseInternalApplicationID(appFilter applicationFilter) {
 	app := application{
 		appIP:     appFilter.srcIP,
-		appL4Port: appFilter.srcPort,
+		appL4Port: appFilter.srcPortFilter.asExactMatchUnchecked().port,
 		appProto:  appFilter.proto,
 	}
 
@@ -589,12 +589,12 @@ func (up4 *UP4) getOrAllocateInternalApplicationID(pdr pdr) (uint8, error) {
 	if pdr.IsUplink() {
 		app = application{
 			appIP:     pdr.appFilter.dstIP,
-			appL4Port: pdr.appFilter.dstPort,
+			appL4Port: pdr.appFilter.dstPortFilter.asExactMatchUnchecked().port,
 		}
 	} else if pdr.IsDownlink() {
 		app = application{
 			appIP:     pdr.appFilter.srcIP,
-			appL4Port: pdr.appFilter.srcPort,
+			appL4Port: pdr.appFilter.srcPortFilter.asExactMatchUnchecked().port,
 		}
 	}
 

--- a/pfcpiface/up4.go
+++ b/pfcpiface/up4.go
@@ -50,7 +50,7 @@ const (
 
 type application struct {
 	appIP     uint32
-	appL4Port portFilter
+	appL4Port portRange
 	appProto  uint8
 }
 

--- a/pfcpiface/up4.go
+++ b/pfcpiface/up4.go
@@ -573,7 +573,7 @@ func (up4 *UP4) allocateInternalApplicationID(app application) (uint8, error) {
 func (up4 *UP4) releaseInternalApplicationID(appFilter applicationFilter) {
 	app := application{
 		appIP:     appFilter.srcIP,
-		appL4Port: appFilter.srcPortFilter,
+		appL4Port: appFilter.srcPortRange,
 		appProto:  appFilter.proto,
 	}
 
@@ -589,12 +589,12 @@ func (up4 *UP4) getOrAllocateInternalApplicationID(pdr pdr) (uint8, error) {
 	if pdr.IsUplink() {
 		app = application{
 			appIP:     pdr.appFilter.dstIP,
-			appL4Port: pdr.appFilter.dstPortFilter,
+			appL4Port: pdr.appFilter.dstPortRange,
 		}
 	} else if pdr.IsDownlink() {
 		app = application{
 			appIP:     pdr.appFilter.srcIP,
-			appL4Port: pdr.appFilter.srcPortFilter,
+			appL4Port: pdr.appFilter.srcPortRange,
 		}
 	}
 

--- a/pfcpiface/up4.go
+++ b/pfcpiface/up4.go
@@ -50,7 +50,7 @@ const (
 
 type application struct {
 	appIP     uint32
-	appL4Port uint16
+	appL4Port portFilter
 	appProto  uint8
 }
 
@@ -573,7 +573,7 @@ func (up4 *UP4) allocateInternalApplicationID(app application) (uint8, error) {
 func (up4 *UP4) releaseInternalApplicationID(appFilter applicationFilter) {
 	app := application{
 		appIP:     appFilter.srcIP,
-		appL4Port: appFilter.srcPortFilter.asExactMatchUnchecked().port,
+		appL4Port: appFilter.srcPortFilter,
 		appProto:  appFilter.proto,
 	}
 
@@ -589,12 +589,12 @@ func (up4 *UP4) getOrAllocateInternalApplicationID(pdr pdr) (uint8, error) {
 	if pdr.IsUplink() {
 		app = application{
 			appIP:     pdr.appFilter.dstIP,
-			appL4Port: pdr.appFilter.dstPortFilter.asExactMatchUnchecked().port,
+			appL4Port: pdr.appFilter.dstPortFilter,
 		}
 	} else if pdr.IsDownlink() {
 		app = application{
 			appIP:     pdr.appFilter.srcIP,
-			appL4Port: pdr.appFilter.srcPortFilter.asExactMatchUnchecked().port,
+			appL4Port: pdr.appFilter.srcPortFilter,
 		}
 	}
 


### PR DESCRIPTION
This PR adds the notion of `PortRange`s to PDRs in PFCP agent. Those replace the existing `<port, mask>` combo with a range type that can represent exact matches, some ternary matches and, new, range matches.
At the same time this adds range match emulation to the BESS-upf, by translating ranges into a equivalent set of ternary rules.

Limitations:
- Only one (1) true port range is allowed per PDR, either src or dest. True range means not wildcard or exact match.