### PR TITLE
Don't remove application filters on session deletion

### DIFF
--- a/pfcpiface/up4.go
+++ b/pfcpiface/up4.go
@@ -706,7 +706,11 @@ func (up4 *UP4) modifyUP4ForwardingConfiguration(pdrs []pdr, allFARs []far, meth
 				pdrLog.Error("failed to get or allocate internal application ID")
 				return err
 			}
+		}
 
+		// TODO: the same app filter can be simultaneously used by another UE session. We cannot remove it.
+		//  We should come up with a way to check if an app filter is still in use.
+		if applicationID != 0 && methodType != p4.Update_DELETE {
 			applicationsEntry, err = up4.p4RtTranslator.BuildApplicationsTableEntry(pdr, applicationID)
 			if err != nil {
 				return ErrOperationFailedWithReason("build P4rt table entry for Applications table", err.Error())


### PR DESCRIPTION
The same application filter can be simultaneously used by different UE sessions. If we remove application filter for a given UE, it it likely that we break the forwarding state for different UE session, making use of the same application filter.

This change avoids removing application filters from UP4 pipeline on PFCP Session Deletion Request.

The side effect of this change is that applications table is not cleared even if there is no UE session making use of an application filter. This is tracked by SDFAB-960. 