### PR TITLE
Use a time-based P4RT election ID in tests

### DIFF
--- a/test/integration/basic_test.go
+++ b/test/integration/basic_test.go
@@ -4,6 +4,7 @@
 package integration
 
 import (
+	log "github.com/sirupsen/logrus"
 	"testing"
 	"time"
 
@@ -44,7 +45,7 @@ var (
 
 func init() {
 	if err := initMockUP4(); err != nil {
-		panic("failed to initialize mock-up4")
+		panic("failed to initialize mock-up4: " + err.Error())
 	}
 
 	providers.RunDockerCommand("pfcpiface", "/bin/pfcpiface -config /config.json")
@@ -53,8 +54,16 @@ func init() {
 	time.Sleep(time.Second * 3)
 }
 
+func TimeBasedElectionId() p4_v1.Uint128 {
+	now := time.Now()
+	return p4_v1.Uint128{
+		High: uint64(now.Unix()),
+		Low: uint64(now.UnixMilli() % 1000),
+	}
+}
+
 func initMockUP4() (err error) {
-	p4rtClient, err := providers.ConnectP4rt("127.0.0.1:50001", p4_v1.Uint128{High: 0, Low: 1})
+	p4rtClient, err := providers.ConnectP4rt("127.0.0.1:50001", TimeBasedElectionId())
 	if err != nil {
 		return err
 	}

--- a/test/integration/basic_test.go
+++ b/test/integration/basic_test.go
@@ -58,7 +58,7 @@ func TimeBasedElectionId() p4_v1.Uint128 {
 	now := time.Now()
 	return p4_v1.Uint128{
 		High: uint64(now.Unix()),
-		Low: uint64(now.UnixMilli() % 1000),
+		Low:  uint64(now.UnixMilli() % 1000),
 	}
 }
 

--- a/test/integration/basic_test.go
+++ b/test/integration/basic_test.go
@@ -52,6 +52,7 @@ func init() {
 	// wait for PFCP Agent to initialize
 	time.Sleep(time.Second * 3)
 }
+
 // Generates an election id that is monotonically increasing with time.
 // Specifically, the upper 64 bits are the unix timestamp in seconds, and the
 // lower 64 bits are the remaining nanoseconds. This is compatible with

--- a/test/integration/basic_test.go
+++ b/test/integration/basic_test.go
@@ -52,7 +52,13 @@ func init() {
 	// wait for PFCP Agent to initialize
 	time.Sleep(time.Second * 3)
 }
-
+// Generates an election id that is monotonically increasing with time.
+// Specifically, the upper 64 bits are the unix timestamp in seconds, and the
+// lower 64 bits are the remaining nanoseconds. This is compatible with
+// election-systems that use the same epoch-based election IDs, and in that
+// case, this election ID will be guaranteed to be higher than any previous
+// election ID. This is useful in tests where repeated connections need to
+// acquire mastership reliably.
 func TimeBasedElectionId() p4_v1.Uint128 {
 	now := time.Now()
 	return p4_v1.Uint128{

--- a/test/integration/basic_test.go
+++ b/test/integration/basic_test.go
@@ -4,7 +4,6 @@
 package integration
 
 import (
-	log "github.com/sirupsen/logrus"
 	"testing"
 	"time"
 
@@ -58,7 +57,7 @@ func TimeBasedElectionId() p4_v1.Uint128 {
 	now := time.Now()
 	return p4_v1.Uint128{
 		High: uint64(now.Unix()),
-		Low:  uint64(now.UnixMilli() % 1000),
+		Low:  uint64(now.UnixNano() % 1e9),
 	}
 }
 


### PR DESCRIPTION
Allows reconnects without having to manually increasing the ID.

I hit this issue when trying to re-run the integration tests against an existing instance.

See: https://github.com/pins/pins-infra/blob/master/p4_pdpi/p4_runtime_session.h#L52-L61