### PR TITLE
Move config parsing and validation into `config.go`

### DIFF
--- a/conf/upf.json
+++ b/conf/upf.json
@@ -1,5 +1,5 @@
 {
-    "": "Vdev or sim support. Enable `\"mode\": \"af_xdp\"` to enable AF_XDP mode, or `\"mode\": \"af_packet\"` to enable AF_PACKET mode, or `\"mode\": \"sim\"` to generate synthetic traffic from BESS's Source module",
+    "": "Vdev or sim support. Enable `\"mode\": \"af_xdp\"` to enable AF_XDP mode, or `\"mode\": \"af_packet\"` to enable AF_PACKET mode, `\"mode\": \"sim\"` to generate synthetic traffic from BESS's Source module or \"mode\": \"\" when running with UP4",
     "": "mode: af_xdp",
     "": "mode: af_packet",
     "": "mode: sim",

--- a/conf/upf.json
+++ b/conf/upf.json
@@ -97,9 +97,6 @@
     "enable_hbTimer": false,
     "": "heart_beat_interval: 5s",
 
-    "enable_ue_ip_alloc": false,
-    "ue_ip_pool": "10.250.0.0/16",
-
     "qci_qos_config": [
         {
             "": "Default values for QERs with QCI/QFI not listed below",
@@ -141,6 +138,8 @@
         "peers": ["148.162.12.214"],
         "dnn": "internet",
         "http_port": "8080",
+        "enable_ue_ip_alloc": false,
+        "ue_ip_pool": "10.250.0.0/16",
         "" : "use_fqdn: true",
         "" : "hostname: upf-0"
     },

--- a/conf/upf.json
+++ b/conf/upf.json
@@ -3,6 +3,7 @@
     "": "mode: af_xdp",
     "": "mode: af_packet",
     "": "mode: sim",
+    "mode": "dpdk",
 
     "table_sizes": {
         "": "Example sizes based on sim mode and 50K sessions. Customize as per your control plane",
@@ -96,6 +97,9 @@
     "enable_hbTimer": false,
     "": "heart_beat_interval: 5s",
 
+    "enable_ue_ip_alloc": false,
+    "ue_ip_pool": "10.250.0.0/16",
+
     "qci_qos_config": [
         {
             "": "Default values for QERs with QCI/QFI not listed below",
@@ -137,17 +141,14 @@
         "peers": ["148.162.12.214"],
         "dnn": "internet",
         "http_port": "8080",
-        "enable_ue_ip_alloc": false,
-        "ue_ip_pool": "10.250.0.0/16",
         "" : "use_fqdn: true",
         "" : "hostname: upf-0"
     },
 
     "": "p4rtc interface settings",
     "p4rtciface": {
-    "access_ip": "172.17.0.1/32",
-    "p4rtc_server": "onos",
-    "p4rtc_port": "51001",
-    "ue_ip_pool": "10.250.0.0/24"
+        "access_ip": "172.17.0.1/32",
+        "p4rtc_server": "onos",
+        "p4rtc_port": "51001"
     }
 }

--- a/pfcpiface/config.go
+++ b/pfcpiface/config.go
@@ -94,16 +94,6 @@ type P4rtcInfo struct {
 
 // validateConf checks that the given config reaches a baseline of correctness.
 func validateConf(conf Conf) error {
-	validModes := map[string]struct{}{
-		"af_xdp":    {},
-		"af_packet": {},
-		"dpdk":      {},
-		"sim":       {},
-	}
-	if _, ok := validModes[conf.Mode]; !ok {
-		return ErrInvalidArgumentWithReason("conf.Mode", conf.Mode, "invalid mode")
-	}
-
 	if conf.EnableP4rt {
 		_, _, err := net.ParseCIDR(conf.P4rtcIface.AccessIP)
 		if err != nil {
@@ -113,6 +103,21 @@ func validateConf(conf Conf) error {
 		_, _, err = net.ParseCIDR(conf.P4rtcIface.UEIPPool)
 		if err != nil {
 			return err
+		}
+
+		if conf.Mode != "" {
+			return ErrInvalidArgumentWithReason("conf.Mode", conf.Mode, "mode must not be set for UP4")
+		}
+	} else {
+		// Mode is only relevant in a BESS deployment.
+		validModes := map[string]struct{}{
+			"af_xdp":    {},
+			"af_packet": {},
+			"dpdk":      {},
+			"sim":       {},
+		}
+		if _, ok := validModes[conf.Mode]; !ok {
+			return ErrInvalidArgumentWithReason("conf.Mode", conf.Mode, "invalid mode")
 		}
 	}
 

--- a/pfcpiface/config.go
+++ b/pfcpiface/config.go
@@ -37,6 +37,8 @@ type Conf struct {
 	RespTimeout       string           `json:"resp_timeout"`
 	EnableHBTimer     bool             `json:"enable_hbTimer"`
 	HeartBeatInterval string           `json:"heart_beat_interval"`
+	EnableUeIPAlloc   bool             `json:"enable_ue_ip_alloc"`
+	UEIPPool          string           `json:"ue_ip_pool"`
 }
 
 // QciQosConfig : Qos configured attributes.
@@ -70,13 +72,11 @@ type SimModeInfo struct {
 
 // CPIfaceInfo : CPIface interface settings.
 type CPIfaceInfo struct {
-	Peers           []string `json:"peers"`
-	UseFQDN         bool     `json:"use_fqdn"`
-	NodeID          string   `json:"hostname"`
-	EnableUeIPAlloc bool     `json:"enable_ue_ip_alloc"`
-	UEIPPool        string   `json:"ue_ip_pool"`
-	HTTPPort        string   `json:"http_port"`
-	Dnn             string   `json:"dnn"`
+	Peers    []string `json:"peers"`
+	UseFQDN  bool     `json:"use_fqdn"`
+	NodeID   string   `json:"hostname"`
+	HTTPPort string   `json:"http_port"`
+	Dnn      string   `json:"dnn"`
 }
 
 // IfaceType : Gateway interface struct.
@@ -89,7 +89,6 @@ type P4rtcInfo struct {
 	AccessIP    string `json:"access_ip"`
 	P4rtcServer string `json:"p4rtc_server"`
 	P4rtcPort   string `json:"p4rtc_port"`
-	UEIPPool    string `json:"ue_ip_pool"`
 }
 
 // validateConf checks that the given config reaches a baseline of correctness.
@@ -98,11 +97,6 @@ func validateConf(conf Conf) error {
 		_, _, err := net.ParseCIDR(conf.P4rtcIface.AccessIP)
 		if err != nil {
 			return ErrInvalidArgumentWithReason("conf.P4rtcIface.AccessIP", conf.P4rtcIface.AccessIP, err.Error())
-		}
-
-		_, _, err = net.ParseCIDR(conf.P4rtcIface.UEIPPool)
-		if err != nil {
-			return ErrInvalidArgumentWithReason("conf.P4rtcIface.UEIPPool", conf.P4rtcIface.UEIPPool, err.Error())
 		}
 
 		if conf.Mode != "" {
@@ -121,16 +115,16 @@ func validateConf(conf Conf) error {
 		}
 	}
 
-	if conf.CPIface.EnableUeIPAlloc {
-		_, _, err := net.ParseCIDR(conf.CPIface.UEIPPool)
+	if conf.EnableUeIPAlloc {
+		_, _, err := net.ParseCIDR(conf.UEIPPool)
 		if err != nil {
-			return ErrInvalidArgumentWithReason("conf.CPIface.UEIPPool", conf.CPIface.UEIPPool, err.Error())
+			return ErrInvalidArgumentWithReason("conf.UEIPPool", conf.UEIPPool, err.Error())
 		}
 	}
 
 	for _, peer := range conf.CPIface.Peers {
 		ip := net.ParseIP(peer)
-		if ip != nil {
+		if ip == nil {
 			return ErrInvalidArgumentWithReason("conf.CPIface.Peers", peer, "invalid IP")
 		}
 	}

--- a/pfcpiface/config.go
+++ b/pfcpiface/config.go
@@ -37,8 +37,6 @@ type Conf struct {
 	RespTimeout       string           `json:"resp_timeout"`
 	EnableHBTimer     bool             `json:"enable_hbTimer"`
 	HeartBeatInterval string           `json:"heart_beat_interval"`
-	EnableUeIPAlloc   bool             `json:"enable_ue_ip_alloc"`
-	UEIPPool          string           `json:"ue_ip_pool"`
 }
 
 // QciQosConfig : Qos configured attributes.
@@ -72,11 +70,13 @@ type SimModeInfo struct {
 
 // CPIfaceInfo : CPIface interface settings.
 type CPIfaceInfo struct {
-	Peers    []string `json:"peers"`
-	UseFQDN  bool     `json:"use_fqdn"`
-	NodeID   string   `json:"hostname"`
-	HTTPPort string   `json:"http_port"`
-	Dnn      string   `json:"dnn"`
+	Peers           []string `json:"peers"`
+	UseFQDN         bool     `json:"use_fqdn"`
+	NodeID          string   `json:"hostname"`
+	HTTPPort        string   `json:"http_port"`
+	Dnn             string   `json:"dnn"`
+	EnableUeIPAlloc bool     `json:"enable_ue_ip_alloc"`
+	UEIPPool        string   `json:"ue_ip_pool"`
 }
 
 // IfaceType : Gateway interface struct.
@@ -99,9 +99,9 @@ func validateConf(conf Conf) error {
 			return ErrInvalidArgumentWithReason("conf.P4rtcIface.AccessIP", conf.P4rtcIface.AccessIP, err.Error())
 		}
 
-		if !conf.EnableUeIPAlloc {
+		if !conf.CPIface.EnableUeIPAlloc {
 			return ErrInvalidArgumentWithReason("conf.EnableUeIPAlloc",
-				conf.EnableUeIPAlloc, "UE IP pool allocation must be enabled in P4RT mode")
+				conf.CPIface.EnableUeIPAlloc, "UE IP pool allocation must be enabled in P4RT mode")
 		}
 
 		if conf.Mode != "" {
@@ -120,10 +120,10 @@ func validateConf(conf Conf) error {
 		}
 	}
 
-	if conf.EnableUeIPAlloc {
-		_, _, err := net.ParseCIDR(conf.UEIPPool)
+	if conf.CPIface.EnableUeIPAlloc {
+		_, _, err := net.ParseCIDR(conf.CPIface.UEIPPool)
 		if err != nil {
-			return ErrInvalidArgumentWithReason("conf.UEIPPool", conf.UEIPPool, err.Error())
+			return ErrInvalidArgumentWithReason("conf.UEIPPool", conf.CPIface.UEIPPool, err.Error())
 		}
 	}
 

--- a/pfcpiface/config.go
+++ b/pfcpiface/config.go
@@ -84,6 +84,14 @@ type IfaceType struct {
 	IfName string `json:"ifname"`
 }
 
+// P4rtcInfo : P4 runtime interface settings.
+type P4rtcInfo struct {
+	AccessIP    string `json:"access_ip"`
+	P4rtcServer string `json:"p4rtc_server"`
+	P4rtcPort   string `json:"p4rtc_port"`
+	UEIPPool    string `json:"ue_ip_pool"`
+}
+
 // validateConf checks that the given config reaches a baseline of correctness.
 func validateConf(conf Conf) error {
 	validModes := map[string]struct{}{
@@ -102,7 +110,7 @@ func validateConf(conf Conf) error {
 			return err
 		}
 
-		_, _, err = net.ParseCIDR(conf.P4rtcIface.UEIP)
+		_, _, err = net.ParseCIDR(conf.P4rtcIface.UEIPPool)
 		if err != nil {
 			return err
 		}

--- a/pfcpiface/config.go
+++ b/pfcpiface/config.go
@@ -160,8 +160,8 @@ func validateConf(conf Conf) error {
 	return nil
 }
 
-// ParseJSON : parse json file and populate corresponding struct.
-func ParseJSON(filepath string) (Conf, error) {
+// LoadConfigFile : parse json file and populate corresponding struct.
+func LoadConfigFile(filepath string) (Conf, error) {
 	// Open up file.
 	jsonFile, err := os.Open(filepath)
 	if err != nil {

--- a/pfcpiface/config.go
+++ b/pfcpiface/config.go
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2022-present Open Networking Foundation
+
+package main
+
+import (
+	log "github.com/sirupsen/logrus"
+	"net"
+	"time"
+
+	"encoding/json"
+	"io/ioutil"
+	"os"
+)
+
+// Conf : Json conf struct.
+type Conf struct {
+	Mode              string           `json:"mode"`
+	AccessIface       IfaceType        `json:"access"`
+	CoreIface         IfaceType        `json:"core"`
+	CPIface           CPIfaceInfo      `json:"cpiface"`
+	P4rtcIface        P4rtcInfo        `json:"p4rtciface"`
+	EnableP4rt        bool             `json:"enable_p4rt"`
+	EnableFlowMeasure bool             `json:"measure_flow"`
+	SimInfo           SimModeInfo      `json:"sim"`
+	ConnTimeout       uint32           `json:"conn_timeout"` // TODO(max): unused, remove
+	ReadTimeout       uint32           `json:"read_timeout"` // TODO(max): convert to duration string
+	EnableNotifyBess  bool             `json:"enable_notify_bess"`
+	EnableEndMarker   bool             `json:"enable_end_marker"`
+	NotifySockAddr    string           `json:"notify_sockaddr"`
+	EndMarkerSockAddr string           `json:"endmarker_sockaddr"`
+	LogLevel          string           `json:"log_level"`
+	QciQosConfig      []QciQosConfig   `json:"qci_qos_config"`
+	SliceMeterConfig  SliceMeterConfig `json:"slice_rate_limit_config"`
+	MaxReqRetries     uint8            `json:"max_req_retries"`
+	RespTimeout       string           `json:"resp_timeout"`
+	EnableHBTimer     bool             `json:"enable_hbTimer"`
+	HeartBeatInterval string           `json:"heart_beat_interval"`
+}
+
+// QciQosConfig : Qos configured attributes.
+type QciQosConfig struct {
+	QCI                uint8  `json:"qci"`
+	CBS                uint32 `json:"cbs"`
+	PBS                uint32 `json:"pbs"`
+	EBS                uint32 `json:"ebs"`
+	BurstDurationMs    uint32 `json:"burst_duration_ms"`
+	SchedulingPriority uint32 `json:"priority"`
+}
+
+type SliceMeterConfig struct {
+	N6RateBps    uint64 `json:"n6_bps"`
+	N6BurstBytes uint64 `json:"n6_burst_bytes"`
+	N3RateBps    uint64 `json:"n3_bps"`
+	N3BurstBytes uint64 `json:"n3_burst_bytes"`
+}
+
+// SimModeInfo : Sim mode attributes.
+type SimModeInfo struct {
+	MaxSessions uint32 `json:"max_sessions"`
+	StartUEIP   net.IP `json:"start_ue_ip"`
+	StartENBIP  net.IP `json:"start_enb_ip"`
+	StartAUPFIP net.IP `json:"start_aupf_ip"`
+	N6AppIP     net.IP `json:"n6_app_ip"`
+	N9AppIP     net.IP `json:"n9_app_ip"`
+	StartN3TEID string `json:"start_n3_teid"`
+	StartN9TEID string `json:"start_n9_teid"`
+}
+
+// CPIfaceInfo : CPIface interface settings.
+type CPIfaceInfo struct {
+	Peers           []string `json:"peers"`
+	UseFQDN         bool     `json:"use_fqdn"`
+	NodeID          string   `json:"hostname"`
+	EnableUeIPAlloc bool     `json:"enable_ue_ip_alloc"`
+	UEIPPool        string   `json:"ue_ip_pool"`
+	HTTPPort        string   `json:"http_port"`
+	Dnn             string   `json:"dnn"`
+}
+
+// IfaceType : Gateway interface struct.
+type IfaceType struct {
+	IfName string `json:"ifname"`
+}
+
+// validateConf checks that the given config reaches a baseline of correctness.
+func validateConf(conf Conf) error {
+	validModes := map[string]struct{}{
+		"af_xdp":    {},
+		"af_packet": {},
+		"dpdk":      {},
+		"sim":       {},
+	}
+	if _, ok := validModes[conf.Mode]; !ok {
+		return ErrInvalidArgumentWithReason("conf.Mode", conf.Mode, "invalid mode")
+	}
+
+	if conf.EnableP4rt {
+		_, _, err := net.ParseCIDR(conf.P4rtcIface.AccessIP)
+		if err != nil {
+			return err
+		}
+		_, _, err = net.ParseCIDR(conf.P4rtcIface.UEIP)
+		if err != nil {
+			return err
+		}
+	}
+
+	if conf.CPIface.EnableUeIPAlloc {
+		_, _, err := net.ParseCIDR(conf.CPIface.UEIPPool)
+		if err != nil {
+			return err
+		}
+	}
+	for _, peer := range conf.CPIface.Peers {
+		ip := net.ParseIP(peer)
+		if ip != nil {
+			return ErrInvalidArgumentWithReason("conf.CPIface.Peers", peer, "invalid IP")
+		}
+	}
+
+	if _, err := log.ParseLevel(conf.LogLevel); err != nil {
+		return err
+	}
+
+	if _, err := time.ParseDuration(conf.RespTimeout); err != nil {
+		return ErrInvalidArgumentWithReason("conf.RespTimeout", conf.RespTimeout, "invalid duration")
+	}
+
+	if conf.ReadTimeout == 0 {
+		return ErrInvalidArgumentWithReason("conf.ReadTimeout", conf.ReadTimeout, "invalid duration")
+	}
+
+	if conf.MaxReqRetries == 0 {
+		return ErrInvalidArgumentWithReason("conf.MaxReqRetries", conf.MaxReqRetries, "invalid number of retries")
+	}
+
+	if conf.EnableHBTimer {
+		if _, err := time.ParseDuration(conf.HeartBeatInterval); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ParseJSON : parse json file and populate corresponding struct.
+func ParseJSON(filepath string) (Conf, error) {
+	// Open up file.
+	jsonFile, err := os.Open(filepath)
+	if err != nil {
+		return Conf{}, err
+	}
+	defer jsonFile.Close()
+
+	// Read our file into memory.
+	byteValue, err := ioutil.ReadAll(jsonFile)
+	if err != nil {
+		return Conf{}, err
+	}
+
+	var conf Conf
+	err = json.Unmarshal(byteValue, &conf)
+	if err != nil {
+		return Conf{}, err
+	}
+
+	// Set defaults, when missing.
+	if conf.LogLevel == "" {
+		conf.LogLevel = "info"
+	}
+	if conf.RespTimeout == "" {
+		conf.RespTimeout = respTimeoutDefault.String()
+	}
+	if conf.ReadTimeout == 0 {
+		conf.ReadTimeout = uint32(readTimeoutDefault.Seconds())
+	}
+	if conf.MaxReqRetries == 0 {
+		conf.MaxReqRetries = maxReqRetriesDefault
+	}
+
+	// Perform basic validation.
+	err = validateConf(conf)
+	if err != nil {
+		return Conf{}, err
+	}
+
+	return conf, nil
+}

--- a/pfcpiface/config.go
+++ b/pfcpiface/config.go
@@ -124,7 +124,7 @@ func validateConf(conf Conf) error {
 	if conf.CPIface.EnableUeIPAlloc {
 		_, _, err := net.ParseCIDR(conf.CPIface.UEIPPool)
 		if err != nil {
-			return err
+			return ErrInvalidArgumentWithReason("conf.CPIface.UEIPPool", conf.CPIface.UEIPPool, err.Error())
 		}
 	}
 

--- a/pfcpiface/config.go
+++ b/pfcpiface/config.go
@@ -97,12 +97,12 @@ func validateConf(conf Conf) error {
 	if conf.EnableP4rt {
 		_, _, err := net.ParseCIDR(conf.P4rtcIface.AccessIP)
 		if err != nil {
-			return err
+			return ErrInvalidArgumentWithReason("conf.P4rtcIface.AccessIP", conf.P4rtcIface.AccessIP, err.Error())
 		}
 
 		_, _, err = net.ParseCIDR(conf.P4rtcIface.UEIPPool)
 		if err != nil {
-			return err
+			return ErrInvalidArgumentWithReason("conf.P4rtcIface.UEIPPool", conf.P4rtcIface.UEIPPool, err.Error())
 		}
 
 		if conf.Mode != "" {

--- a/pfcpiface/config.go
+++ b/pfcpiface/config.go
@@ -99,6 +99,11 @@ func validateConf(conf Conf) error {
 			return ErrInvalidArgumentWithReason("conf.P4rtcIface.AccessIP", conf.P4rtcIface.AccessIP, err.Error())
 		}
 
+		if !conf.EnableUeIPAlloc {
+			return ErrInvalidArgumentWithReason("conf.EnableUeIPAlloc",
+				conf.EnableUeIPAlloc, "UE IP pool allocation must be enabled in P4RT mode")
+		}
+
 		if conf.Mode != "" {
 			return ErrInvalidArgumentWithReason("conf.Mode", conf.Mode, "mode must not be set for UP4")
 		}

--- a/pfcpiface/config.go
+++ b/pfcpiface/config.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	log "github.com/sirupsen/logrus"
+
 	"net"
 	"time"
 
@@ -100,6 +101,7 @@ func validateConf(conf Conf) error {
 		if err != nil {
 			return err
 		}
+
 		_, _, err = net.ParseCIDR(conf.P4rtcIface.UEIP)
 		if err != nil {
 			return err
@@ -112,6 +114,7 @@ func validateConf(conf Conf) error {
 			return err
 		}
 	}
+
 	for _, peer := range conf.CPIface.Peers {
 		ip := net.ParseIP(peer)
 		if ip != nil {
@@ -160,6 +163,7 @@ func ParseJSON(filepath string) (Conf, error) {
 	}
 
 	var conf Conf
+
 	err = json.Unmarshal(byteValue, &conf)
 	if err != nil {
 		return Conf{}, err
@@ -169,12 +173,15 @@ func ParseJSON(filepath string) (Conf, error) {
 	if conf.LogLevel == "" {
 		conf.LogLevel = "info"
 	}
+
 	if conf.RespTimeout == "" {
 		conf.RespTimeout = respTimeoutDefault.String()
 	}
+
 	if conf.ReadTimeout == 0 {
 		conf.ReadTimeout = uint32(readTimeoutDefault.Seconds())
 	}
+
 	if conf.MaxReqRetries == 0 {
 		conf.MaxReqRetries = maxReqRetriesDefault
 	}

--- a/pfcpiface/config.go
+++ b/pfcpiface/config.go
@@ -30,7 +30,7 @@ type Conf struct {
 	EnableEndMarker   bool             `json:"enable_end_marker"`
 	NotifySockAddr    string           `json:"notify_sockaddr"`
 	EndMarkerSockAddr string           `json:"endmarker_sockaddr"`
-	LogLevel          string           `json:"log_level"`
+	LogLevel          log.Level        `json:"log_level"`
 	QciQosConfig      []QciQosConfig   `json:"qci_qos_config"`
 	SliceMeterConfig  SliceMeterConfig `json:"slice_rate_limit_config"`
 	MaxReqRetries     uint8            `json:"max_req_retries"`
@@ -135,10 +135,6 @@ func validateConf(conf Conf) error {
 		}
 	}
 
-	if _, err := log.ParseLevel(conf.LogLevel); err != nil {
-		return err
-	}
-
 	if _, err := time.ParseDuration(conf.RespTimeout); err != nil {
 		return ErrInvalidArgumentWithReason("conf.RespTimeout", conf.RespTimeout, "invalid duration")
 	}
@@ -183,10 +179,6 @@ func LoadConfigFile(filepath string) (Conf, error) {
 	}
 
 	// Set defaults, when missing.
-	if conf.LogLevel == "" {
-		conf.LogLevel = "info"
-	}
-
 	if conf.RespTimeout == "" {
 		conf.RespTimeout = respTimeoutDefault.String()
 	}

--- a/pfcpiface/config_test.go
+++ b/pfcpiface/config_test.go
@@ -1,11 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2022-present Open Networking Foundation
+
 package main
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"io/fs"
 	"io/ioutil"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func mustWriteStringToDisk(s string, path string) {

--- a/pfcpiface/config_test.go
+++ b/pfcpiface/config_test.go
@@ -8,7 +8,6 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -19,8 +18,8 @@ func mustWriteStringToDisk(s string, path string) {
 	}
 }
 
-func TestParseJSON(t *testing.T) {
-	t.Run("config is preserved", func(t *testing.T) {
+func TestLoadConfigFile(t *testing.T) {
+	t.Run("sample config is valid", func(t *testing.T) {
 		s := `{
 			"mode": "dpdk",
 			"log_level": "info",
@@ -63,8 +62,7 @@ func TestParseJSON(t *testing.T) {
 		confPath := t.TempDir() + "/conf.json"
 		mustWriteStringToDisk(s, confPath)
 
-		got, err := ParseJSON(confPath)
+		_, err := LoadConfigFile(confPath)
 		require.NoError(t, err)
-		assert.Equal(t, "info", got.LogLevel)
 	})
 }

--- a/pfcpiface/config_test.go
+++ b/pfcpiface/config_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"io/fs"
+	"io/ioutil"
+	"testing"
+)
+
+func mustWriteStringToDisk(s string, path string) {
+	err := ioutil.WriteFile(path, []byte(s), fs.ModePerm)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func TestParseJSON(t *testing.T) {
+	t.Run("config is preserved", func(t *testing.T) {
+		s := `{
+			"mode": "dpdk",
+			"log_level": "info",
+			"workers": 1,
+			"max_sessions": 50000,
+			"table_sizes": {
+				"pdrLookup": 50000,
+				"appQERLookup": 200000,
+				"sessionQERLookup": 100000,
+				"farLookup": 150000
+			},
+			"access": {
+				"ifname": "access"
+			},
+			"core": {
+				"ifname": "core"
+			},
+			"measure_upf": true,
+			"measure_flow": true,
+			"enable_notify_bess": true,
+			"notify_sockaddr": "/pod-share/notifycp",
+			"cpiface": {
+				"dnn": "internet",
+				"hostname": "upf",
+				"http_port": "8080"
+			},
+			"n6_bps": 1000000000,
+			"n6_burst_bytes": 12500000,
+			"n3_bps": 1000000000,
+			"n3_burst_bytes": 12500000,
+			"qci_qos_config": [{
+				"qci": 0,
+				"cbs": 50000,
+				"ebs": 50000,
+				"pbs": 50000,
+				"burst_duration_ms": 10,
+				"priority": 7
+			}]
+		}`
+		confPath := t.TempDir() + "/conf.json"
+		mustWriteStringToDisk(s, confPath)
+
+		got, err := ParseJSON(confPath)
+		require.NoError(t, err)
+		assert.Equal(t, "info", got.LogLevel)
+	})
+}

--- a/pfcpiface/config_test.go
+++ b/pfcpiface/config_test.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -64,5 +65,19 @@ func TestLoadConfigFile(t *testing.T) {
 
 		_, err := LoadConfigFile(confPath)
 		require.NoError(t, err)
+	})
+
+	t.Run("all sample configs must be valid", func(t *testing.T) {
+		paths := []string{
+			"../conf/upf.json",
+			"../ptf/config/upf.json",
+			"../test/integration/config/default.json",
+			"../test/integration/config/ue_ip_alloc.json",
+		}
+
+		for _, path := range paths {
+			_, err := LoadConfigFile(path)
+			assert.NoError(t, err, "config %v is not valid", path)
+		}
 	})
 }

--- a/pfcpiface/main.go
+++ b/pfcpiface/main.go
@@ -41,11 +41,7 @@ func main() {
 		log.Fatalln("Error reading conf file:", err)
 	}
 
-	if level, err := log.ParseLevel(conf.LogLevel); err != nil {
-		log.Fatalln(err)
-	} else {
-		log.SetLevel(level)
-	}
+	log.SetLevel(conf.LogLevel)
 
 	log.Infof("%+v", conf)
 

--- a/pfcpiface/main.go
+++ b/pfcpiface/main.go
@@ -1,15 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 Intel Corporation
+// Copyright 2022-present Open Networking Foundation
 
 package main
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"flag"
-	"io/ioutil"
-	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -24,102 +22,6 @@ var (
 	pfcpsim    = flag.Bool("pfcpsim", false, "simulate PFCP")
 )
 
-// Conf : Json conf struct.
-type Conf struct {
-	Mode              string           `json:"mode"`
-	AccessIface       IfaceType        `json:"access"`
-	CoreIface         IfaceType        `json:"core"`
-	CPIface           CPIfaceInfo      `json:"cpiface"`
-	P4rtcIface        P4rtcInfo        `json:"p4rtciface"`
-	EnableP4rt        bool             `json:"enable_p4rt"`
-	EnableFlowMeasure bool             `json:"measure_flow"`
-	SimInfo           SimModeInfo      `json:"sim"`
-	ConnTimeout       uint32           `json:"conn_timeout"`
-	ReadTimeout       uint32           `json:"read_timeout"`
-	EnableNotifyBess  bool             `json:"enable_notify_bess"`
-	EnableEndMarker   bool             `json:"enable_end_marker"`
-	NotifySockAddr    string           `json:"notify_sockaddr"`
-	EndMarkerSockAddr string           `json:"endmarker_sockaddr"`
-	LogLevel          string           `json:"log_level"`
-	QciQosConfig      []QciQosConfig   `json:"qci_qos_config"`
-	SliceMeterConfig  SliceMeterConfig `json:"slice_rate_limit_config"`
-	MaxReqRetries     uint8            `json:"max_req_retries"`
-	RespTimeout       string           `json:"resp_timeout"`
-	EnableHBTimer     bool             `json:"enable_hbTimer"`
-	HeartBeatInterval string           `json:"heart_beat_interval"`
-}
-
-// QciQosConfig : Qos configured attributes.
-type QciQosConfig struct {
-	QCI                uint8  `json:"qci"`
-	CBS                uint32 `json:"cbs"`
-	PBS                uint32 `json:"pbs"`
-	EBS                uint32 `json:"ebs"`
-	BurstDurationMs    uint32 `json:"burst_duration_ms"`
-	SchedulingPriority uint32 `json:"priority"`
-}
-
-type SliceMeterConfig struct {
-	N6RateBps    uint64 `json:"n6_bps"`
-	N6BurstBytes uint64 `json:"n6_burst_bytes"`
-	N3RateBps    uint64 `json:"n3_bps"`
-	N3BurstBytes uint64 `json:"n3_burst_bytes"`
-}
-
-// SimModeInfo : Sim mode attributes.
-type SimModeInfo struct {
-	MaxSessions uint32 `json:"max_sessions"`
-	StartUEIP   net.IP `json:"start_ue_ip"`
-	StartENBIP  net.IP `json:"start_enb_ip"`
-	StartAUPFIP net.IP `json:"start_aupf_ip"`
-	N6AppIP     net.IP `json:"n6_app_ip"`
-	N9AppIP     net.IP `json:"n9_app_ip"`
-	StartN3TEID string `json:"start_n3_teid"`
-	StartN9TEID string `json:"start_n9_teid"`
-}
-
-// CPIfaceInfo : CPIface interface settings.
-type CPIfaceInfo struct {
-	Peers           []string `json:"peers"`
-	UseFQDN         bool     `json:"use_fqdn"`
-	NodeID          string   `json:"hostname"`
-	EnableUeIPAlloc bool     `json:"enable_ue_ip_alloc"`
-	UEIPPool        string   `json:"ue_ip_pool"`
-	HTTPPort        string   `json:"http_port"`
-	Dnn             string   `json:"dnn"`
-}
-
-// IfaceType : Gateway interface struct.
-type IfaceType struct {
-	IfName string `json:"ifname"`
-}
-
-// ParseJSON : parse json file and populate corresponding struct.
-func ParseJSON(filepath *string, conf *Conf) {
-	/* Open up file */
-	jsonFile, err := os.Open(*filepath)
-	if err != nil {
-		log.Fatalln("Error opening file: ", err)
-	}
-	defer jsonFile.Close()
-
-	/* read our opened file */
-	byteValue, err := ioutil.ReadAll(jsonFile)
-	if err != nil {
-		log.Fatalln("Error reading file: ", err)
-	}
-
-	err = json.Unmarshal(byteValue, conf)
-	if err != nil {
-		log.Fatalln("Unable to unmarshal conf attributes:", err)
-	}
-
-	// Set default log level
-	if conf.LogLevel == "" {
-		conf.LogLevel = "info"
-	}
-}
-
 func init() {
 	flag.Var(&simulate, "simulate", "create|delete|create_continue simulated sessions")
 	// Set up logger
@@ -133,13 +35,11 @@ func main() {
 	// cmdline args
 	flag.Parse()
 
-	var (
-		conf Conf
-		fp   fastPath
-	)
-
-	// read and parse json startup file
-	ParseJSON(configPath, &conf)
+	// Read and parse json startup file.
+	conf, err := ParseJSON(*configPath)
+	if err != nil {
+		log.Fatalln("Error reading conf file:", err)
+	}
 
 	if level, err := log.ParseLevel(conf.LogLevel); err != nil {
 		log.Fatalln(err)
@@ -149,6 +49,7 @@ func main() {
 
 	log.Infof("%+v", conf)
 
+	var fp fastPath
 	if conf.EnableP4rt {
 		fp = &UP4{}
 	} else {

--- a/pfcpiface/main.go
+++ b/pfcpiface/main.go
@@ -36,7 +36,7 @@ func main() {
 	flag.Parse()
 
 	// Read and parse json startup file.
-	conf, err := ParseJSON(*configPath)
+	conf, err := LoadConfigFile(*configPath)
 	if err != nil {
 		log.Fatalln("Error reading conf file:", err)
 	}

--- a/pfcpiface/up4.go
+++ b/pfcpiface/up4.go
@@ -31,15 +31,6 @@ var (
 	p4RtcServerPort = flag.String("p4RtcServerPort", "", "P4 Server port")
 )
 
-// FIXME: it should not be here IMO
-// P4rtcInfo : P4 runtime interface settings.
-type P4rtcInfo struct {
-	AccessIP    string `json:"access_ip"`
-	P4rtcServer string `json:"p4rtc_server"`
-	P4rtcPort   string `json:"p4rtc_port"`
-	UEIP        string `json:"ue_ip_pool"`
-}
-
 const (
 	preQosCounterID = iota
 	postQosCounterID

--- a/pfcpiface/up4.go
+++ b/pfcpiface/up4.go
@@ -263,7 +263,7 @@ func (up4 *UP4) setUpfInfo(u *upf, conf *Conf) {
 
 	log.Println("AccessIP: ", up4.accessIP)
 
-	up4.ueIPPool = MustParseStrIP(conf.CPIface.UEIPPool)
+	up4.ueIPPool = MustParseStrIP(conf.UEIPPool)
 
 	log.Infof("UE IP pool: %v", up4.ueIPPool)
 

--- a/pfcpiface/up4.go
+++ b/pfcpiface/up4.go
@@ -245,7 +245,7 @@ func (up4 *UP4) setUpfInfo(u *upf, conf *Conf) {
 
 	log.Println("AccessIP: ", up4.accessIP)
 
-	up4.ueIPPool = MustParseStrIP(conf.UEIPPool)
+	up4.ueIPPool = MustParseStrIP(conf.CPIface.UEIPPool)
 
 	log.Infof("UE IP pool: %v", up4.ueIPPool)
 

--- a/pfcpiface/upf.go
+++ b/pfcpiface/upf.go
@@ -133,10 +133,11 @@ func NewUPF(conf *Conf, fp fastPath) *upf {
 		dnn:               conf.CPIface.Dnn,
 		peers:             conf.CPIface.Peers,
 		reportNotifyChan:  make(chan uint64, 1024),
-		maxReqRetries:     maxReqRetriesDefault,
+		maxReqRetries:     conf.MaxReqRetries,
 		respTimeout:       respTimeoutDefault,
 		enableHBTimer:     conf.EnableHBTimer,
 		hbInterval:        hbIntervalDefault,
+		readTimeout:       time.Second * time.Duration(conf.ReadTimeout),
 	}
 
 	if len(conf.CPIface.Peers) > 0 {
@@ -162,20 +163,9 @@ func NewUPF(conf *Conf, fp fastPath) *upf {
 		}
 	}
 
-	if conf.MaxReqRetries != 0 {
-		u.maxReqRetries = conf.MaxReqRetries
-	}
-
-	if conf.RespTimeout != "" {
-		u.respTimeout, err = time.ParseDuration(conf.RespTimeout)
-		if err != nil {
-			log.Fatalln("Unable to parse resp_timeout")
-		}
-	}
-
-	u.readTimeout = readTimeoutDefault
-	if conf.ReadTimeout != 0 {
-		u.readTimeout = time.Second * time.Duration(conf.ReadTimeout)
+	u.respTimeout, err = time.ParseDuration(conf.RespTimeout)
+	if err != nil {
+		log.Fatalln("Unable to parse resp_timeout")
 	}
 
 	if u.enableHBTimer {

--- a/pfcpiface/upf.go
+++ b/pfcpiface/upf.go
@@ -122,12 +122,12 @@ func NewUPF(conf *Conf, fp fastPath) *upf {
 	}
 
 	u := &upf{
-		enableUeIPAlloc:   conf.CPIface.EnableUeIPAlloc,
+		enableUeIPAlloc:   conf.EnableUeIPAlloc,
 		enableEndMarker:   conf.EnableEndMarker,
 		enableFlowMeasure: conf.EnableFlowMeasure,
 		accessIface:       conf.AccessIface.IfName,
 		coreIface:         conf.CoreIface.IfName,
-		ippoolCidr:        conf.CPIface.UEIPPool,
+		ippoolCidr:        conf.UEIPPool,
 		nodeID:            nodeID,
 		fastPath:          fp,
 		dnn:               conf.CPIface.Dnn,

--- a/pfcpiface/upf.go
+++ b/pfcpiface/upf.go
@@ -122,12 +122,12 @@ func NewUPF(conf *Conf, fp fastPath) *upf {
 	}
 
 	u := &upf{
-		enableUeIPAlloc:   conf.EnableUeIPAlloc,
+		enableUeIPAlloc:   conf.CPIface.EnableUeIPAlloc,
 		enableEndMarker:   conf.EnableEndMarker,
 		enableFlowMeasure: conf.EnableFlowMeasure,
 		accessIface:       conf.AccessIface.IfName,
 		coreIface:         conf.CoreIface.IfName,
-		ippoolCidr:        conf.UEIPPool,
+		ippoolCidr:        conf.CPIface.UEIPPool,
 		nodeID:            nodeID,
 		fastPath:          fp,
 		dnn:               conf.CPIface.Dnn,

--- a/pfcpiface/utils.go
+++ b/pfcpiface/utils.go
@@ -107,7 +107,7 @@ func calcBurstSizeFromRate(kbps uint64, ms uint64) uint64 {
 func MustParseStrIP(address string) *net.IPNet {
 	ip, ipNet, err := net.ParseCIDR(address)
 	if err != nil {
-		log.Fatal("unable to parse IP that we should parse")
+		log.Fatalf("unable to parse IP %v that we should parse", address)
 	}
 
 	log.Info("Parsed IP: ", ip)

--- a/ptf/config/upf.json
+++ b/ptf/config/upf.json
@@ -91,9 +91,6 @@
     "" : "notify_sockaddr: /tmp/notifycp",
     "" : "endmarker_sockaddr: /tmp/pfcpport",
 
-    "enable_ue_ip_alloc": false,
-    "ue_ip_pool": "10.250.0.0/16",
-
     "qci_qos_config": [
         {
             "": "Default values for QERs with QCI/QFI not listed below",
@@ -120,6 +117,8 @@
     "cpiface": {
         "dnn": "internet",
         "http_port": "8080",
+        "enable_ue_ip_alloc": false,
+        "ue_ip_pool": "10.250.0.0/16",
         "" : "use_fqdn: true",
         "" : "hostname: upf-0"
     },

--- a/ptf/config/upf.json
+++ b/ptf/config/upf.json
@@ -91,6 +91,9 @@
     "" : "notify_sockaddr: /tmp/notifycp",
     "" : "endmarker_sockaddr: /tmp/pfcpport",
 
+    "enable_ue_ip_alloc": false,
+    "ue_ip_pool": "10.250.0.0/16",
+
     "qci_qos_config": [
         {
             "": "Default values for QERs with QCI/QFI not listed below",
@@ -117,17 +120,14 @@
     "cpiface": {
         "dnn": "internet",
         "http_port": "8080",
-        "enable_ue_ip_alloc": false,
-        "ue_ip_pool": "10.250.0.0/16",
         "" : "use_fqdn: true",
         "" : "hostname: upf-0"
     },
 
     "": "p4rtc interface settings",
     "p4rtciface": {
-    "access_ip": "172.17.0.1/32",
-    "p4rtc_server": "onos",
-    "p4rtc_port": "51001",
-    "ue_ip_pool": "10.250.0.0/24"
+        "access_ip": "172.17.0.1/32",
+        "p4rtc_server": "onos",
+        "p4rtc_port": "51001"
     }
 }

--- a/test/integration/config/default.json
+++ b/test/integration/config/default.json
@@ -1,8 +1,10 @@
 {
   "enable_p4rt": true,
   "log_level": "trace",
-  "enable_ue_ip_alloc": true,
-  "ue_ip_pool": "10.250.0.0/16",
+  "cpiface": {
+    "enable_ue_ip_alloc": true,
+    "ue_ip_pool": "10.250.0.0/16"
+  },
   "p4rtciface": {
     "p4rtc_server": "mock-up4",
     "p4rtc_port": "50001",

--- a/test/integration/config/default.json
+++ b/test/integration/config/default.json
@@ -1,6 +1,8 @@
 {
   "enable_p4rt": true,
   "log_level": "trace",
+  "enable_ue_ip_alloc": true,
+  "ue_ip_pool": "10.250.0.0/16",
   "p4rtciface": {
     "p4rtc_server": "mock-up4",
     "p4rtc_port": "50001",

--- a/test/integration/config/default.json
+++ b/test/integration/config/default.json
@@ -1,9 +1,6 @@
 {
   "enable_p4rt": true,
   "log_level": "trace",
-  "cpiface": {
-    "ue_ip_pool": "10.250.0.0/16"
-  },
   "p4rtciface": {
     "p4rtc_server": "mock-up4",
     "p4rtc_port": "50001",

--- a/test/integration/config/ue_ip_alloc.json
+++ b/test/integration/config/ue_ip_alloc.json
@@ -1,11 +1,11 @@
 {
   "enable_p4rt": true,
   "log_level": "trace",
+  "enable_ue_ip_alloc": true,
+  "ue_ip_pool": "10.250.0.0/16",
 
   "cpiface": {
-    "dnn": "internet",
-    "enable_ue_ip_alloc": true,
-    "ue_ip_pool": "10.250.0.0/16"
+    "dnn": "internet"
   },
 
   "p4rtciface": {

--- a/test/integration/config/ue_ip_alloc.json
+++ b/test/integration/config/ue_ip_alloc.json
@@ -1,11 +1,11 @@
 {
   "enable_p4rt": true,
   "log_level": "trace",
-  "enable_ue_ip_alloc": true,
-  "ue_ip_pool": "10.250.0.0/16",
 
   "cpiface": {
-    "dnn": "internet"
+    "dnn": "internet",
+    "enable_ue_ip_alloc": true,
+    "ue_ip_pool": "10.250.0.0/16"
   },
 
   "p4rtciface": {


### PR DESCRIPTION
This change collects all the checks, parsers and validations littered around, and puts them in one place.
Defaults are now set in one place and at startup, so the full config can be logged and inspected.