### PR TITLE
Make ue pool, but not allocation, mandatory in P4RT mode

### DIFF
--- a/pfcpiface/config.go
+++ b/pfcpiface/config.go
@@ -99,9 +99,9 @@ func validateConf(conf Conf) error {
 			return ErrInvalidArgumentWithReason("conf.P4rtcIface.AccessIP", conf.P4rtcIface.AccessIP, err.Error())
 		}
 
-		if !conf.CPIface.EnableUeIPAlloc {
-			return ErrInvalidArgumentWithReason("conf.EnableUeIPAlloc",
-				conf.CPIface.EnableUeIPAlloc, "UE IP pool allocation must be enabled in P4RT mode")
+		_, _, err = net.ParseCIDR(conf.CPIface.UEIPPool)
+		if err != nil {
+			return ErrInvalidArgumentWithReason("conf.UEIPPool", conf.CPIface.UEIPPool, err.Error())
 		}
 
 		if conf.Mode != "" {

--- a/test/integration/config/default.json
+++ b/test/integration/config/default.json
@@ -2,7 +2,6 @@
   "enable_p4rt": true,
   "log_level": "trace",
   "cpiface": {
-    "enable_ue_ip_alloc": true,
     "ue_ip_pool": "10.250.0.0/16"
   },
   "p4rtciface": {


### PR DESCRIPTION
The pool must be there for direction detection, but allocation does not have to enabled.