### PR TITLE
Implement graceful shutdown of PFCPIface

### DIFF
--- a/pfcpiface/pfcpiface.go
+++ b/pfcpiface/pfcpiface.go
@@ -7,12 +7,13 @@ import (
 	"context"
 	"errors"
 	"flag"
-	log "github.com/sirupsen/logrus"
 	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 )
 
 var (


### PR DESCRIPTION
This PR enables to stop main Goroutine gracefully. It will be required for BESS/UP4 integration tests. 