### PR TITLE
Disable setting P4Info and device config via configuration file

### DIFF
--- a/conf/upf.json
+++ b/conf/upf.json
@@ -148,8 +148,6 @@
     "p4rtciface": {
         "access_ip": "172.17.0.1/32",
         "p4rtc_server": "onos",
-        "p4rtc_port": "51001",
-        "" : "p4info: /bin/p4info.txt",
-        "" : "device_config: /bin/bmv2.json"
+        "p4rtc_port": "51001"
     }
 }

--- a/pfcpiface/config.go
+++ b/pfcpiface/config.go
@@ -16,12 +16,10 @@ import (
 
 const (
 	// Default values
-	maxReqRetriesDefault    = 5
-	respTimeoutDefault      = 2 * time.Second
-	hbIntervalDefault       = 5 * time.Second
-	readTimeoutDefault      = 15 * time.Second
-	p4InfoPathDefault       = "/bin/p4info.txt"
-	deviceConfigPathDefault = "/bin/bmv2.json"
+	maxReqRetriesDefault = 5
+	respTimeoutDefault   = 2 * time.Second
+	hbIntervalDefault    = 5 * time.Second
+	readTimeoutDefault   = 15 * time.Second
 )
 
 // Conf : Json conf struct.
@@ -96,10 +94,10 @@ type IfaceType struct {
 
 // P4rtcInfo : P4 runtime interface settings.
 type P4rtcInfo struct {
-	AccessIP     string          `json:"access_ip"`
-	P4rtcServer  string          `json:"p4rtc_server"`
-	P4rtcPort    string          `json:"p4rtc_port"`
-	QFIToTC      map[uint8]uint8 `json:"qfi_tc_mapping"`
+	AccessIP    string          `json:"access_ip"`
+	P4rtcServer string          `json:"p4rtc_server"`
+	P4rtcPort   string          `json:"p4rtc_port"`
+	QFIToTC     map[uint8]uint8 `json:"qfi_tc_mapping"`
 }
 
 // validateConf checks that the given config reaches a baseline of correctness.

--- a/pfcpiface/config.go
+++ b/pfcpiface/config.go
@@ -96,8 +96,6 @@ type IfaceType struct {
 
 // P4rtcInfo : P4 runtime interface settings.
 type P4rtcInfo struct {
-	P4Info       string          `json:"p4info"`
-	DeviceConfig string          `json:"device_config"`
 	AccessIP     string          `json:"access_ip"`
 	P4rtcServer  string          `json:"p4rtc_server"`
 	P4rtcPort    string          `json:"p4rtc_port"`
@@ -207,14 +205,6 @@ func LoadConfigFile(filepath string) (Conf, error) {
 		if conf.HeartBeatInterval == "" {
 			conf.HeartBeatInterval = hbIntervalDefault.String()
 		}
-	}
-
-	if conf.P4rtcIface.P4Info == "" {
-		conf.P4rtcIface.P4Info = p4InfoPathDefault
-	}
-
-	if conf.P4rtcIface.DeviceConfig == "" {
-		conf.P4rtcIface.DeviceConfig = deviceConfigPathDefault
 	}
 
 	// Perform basic validation.

--- a/pfcpiface/up4.go
+++ b/pfcpiface/up4.go
@@ -23,6 +23,11 @@ import (
 )
 
 const (
+	p4InfoPath       = "/bin/p4info.txt"
+	deviceConfigPath = "/bin/bmv2.json"
+)
+
+const (
 	preQosCounterID = iota
 	postQosCounterID
 
@@ -201,7 +206,7 @@ func (up4 *UP4) setupChannel() error {
 
 	err = up4.p4client.GetForwardingPipelineConfig()
 	if err != nil {
-		err = up4.p4client.SetForwardingPipelineConfig(up4.conf.P4Info, up4.conf.DeviceConfig)
+		err = up4.p4client.SetForwardingPipelineConfig(p4InfoPath, deviceConfigPath)
 		if err != nil {
 			log.Errorf("set forwarding pipeling config failed: %v", err)
 			return err


### PR DESCRIPTION
If we allow users to pass a custom P4Info/device config at runtime it might cause an inconsistent behaviors since the PFCP Agent code relies on the P4Info/device config passed at packaging time. 