### PR TITLE
Use time based election IDs

### DIFF
--- a/pfcpiface/p4rtc.go
+++ b/pfcpiface/p4rtc.go
@@ -99,6 +99,21 @@ func convertError(err error) error {
 	return p4RtError
 }
 
+// TimeBasedElectionId Generates an election id that is monotonically increasing with time.
+// Specifically, the upper 64 bits are the unix timestamp in seconds, and the
+// lower 64 bits are the remaining nanoseconds. This is compatible with
+// election-systems that use the same epoch-based election IDs, and in that
+// case, this election ID will be guaranteed to be higher than any previous
+// election ID. This is useful in tests where repeated connections need to
+// acquire mastership reliably.
+func TimeBasedElectionId() p4.Uint128 {
+	now := time.Now()
+	return p4.Uint128{
+		High: uint64(now.Unix()),
+		Low:  uint64(now.UnixNano() % 1e9),
+	}
+}
+
 // CheckStatus ... Check client connection status.
 func (c *P4rtClient) CheckStatus() (state int) {
 	return int(c.conn.GetState())

--- a/pfcpiface/p4rtc.go
+++ b/pfcpiface/p4rtc.go
@@ -108,6 +108,7 @@ func convertError(err error) error {
 // acquire mastership reliably.
 func TimeBasedElectionId() p4.Uint128 {
 	now := time.Now()
+
 	return p4.Uint128{
 		High: uint64(now.Unix()),
 		Low:  uint64(now.UnixNano() % 1e9),

--- a/pfcpiface/p4rtc.go
+++ b/pfcpiface/p4rtc.go
@@ -562,7 +562,7 @@ func CreateChannel(host string, deviceID uint64) (*P4rtClient, error) {
 		return nil, err
 	}
 
-	err = client.SetMastership(p4.Uint128{High: 1, Low: 1})
+	err = client.SetMastership(TimeBasedElectionId())
 	if err != nil {
 		log.Println("Set Mastership error: ", err)
 		return nil, err

--- a/pfcpiface/utils.go
+++ b/pfcpiface/utils.go
@@ -6,11 +6,9 @@ package pfcpiface
 
 import (
 	"encoding/binary"
-	p4_v1 "github.com/p4lang/p4runtime/go/p4/v1"
 	"net"
 	"strconv"
 	"strings"
-	"time"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -135,19 +133,4 @@ func GetUnicastAddressFromInterface(interfaceName string) (net.IP, error) {
 	}
 
 	return ip, nil
-}
-
-// TimeBasedElectionId Generates an election id that is monotonically increasing with time.
-// Specifically, the upper 64 bits are the unix timestamp in seconds, and the
-// lower 64 bits are the remaining nanoseconds. This is compatible with
-// election-systems that use the same epoch-based election IDs, and in that
-// case, this election ID will be guaranteed to be higher than any previous
-// election ID. This is useful in tests where repeated connections need to
-// acquire mastership reliably.
-func TimeBasedElectionId() p4_v1.Uint128 {
-	now := time.Now()
-	return p4_v1.Uint128{
-		High: uint64(now.Unix()),
-		Low:  uint64(now.UnixNano() % 1e9),
-	}
 }

--- a/pfcpiface/utils.go
+++ b/pfcpiface/utils.go
@@ -6,9 +6,11 @@ package pfcpiface
 
 import (
 	"encoding/binary"
+	p4_v1 "github.com/p4lang/p4runtime/go/p4/v1"
 	"net"
 	"strconv"
 	"strings"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -133,4 +135,19 @@ func GetUnicastAddressFromInterface(interfaceName string) (net.IP, error) {
 	}
 
 	return ip, nil
+}
+
+// TimeBasedElectionId Generates an election id that is monotonically increasing with time.
+// Specifically, the upper 64 bits are the unix timestamp in seconds, and the
+// lower 64 bits are the remaining nanoseconds. This is compatible with
+// election-systems that use the same epoch-based election IDs, and in that
+// case, this election ID will be guaranteed to be higher than any previous
+// election ID. This is useful in tests where repeated connections need to
+// acquire mastership reliably.
+func TimeBasedElectionId() p4_v1.Uint128 {
+	now := time.Now()
+	return p4_v1.Uint128{
+		High: uint64(now.Unix()),
+		Low:  uint64(now.UnixNano() % 1e9),
+	}
 }

--- a/test/integration/basic_test.go
+++ b/test/integration/basic_test.go
@@ -40,6 +40,14 @@ type testCase struct {
 	desc string
 }
 
+func TimeBasedElectionId() p4_v1.Uint128 {
+	now := time.Now()
+	return p4_v1.Uint128{
+		High: uint64(now.Unix()),
+		Low:  uint64(now.UnixNano() % 1e9),
+	}
+}
+
 func setup(t *testing.T, pfcpAgentConfig string) {
 	providers.RunDockerCommandAttach("pfcpiface",
 		fmt.Sprintf("/bin/pfcpiface -config /config/%s", pfcpAgentConfig))
@@ -56,7 +64,7 @@ func setup(t *testing.T, pfcpAgentConfig string) {
 func teardown(t *testing.T) {
 	// clear Tunnel Peers table
 	// FIXME: Temporary solution. They should be cleared by pfcpiface, see SDFAB-960
-	p4rtClient, _ := providers.ConnectP4rt("127.0.0.1:50001", p4_v1.Uint128{High: 2, Low: 1})
+	p4rtClient, _ := providers.ConnectP4rt("127.0.0.1:50001", TimeBasedElectionId())
 	defer providers.DisconnectP4rt()
 	entries, _ := p4rtClient.ReadTableEntryWildcard("PreQosPipe.tunnel_peers")
 	for _, entry := range entries {
@@ -417,7 +425,7 @@ func testUEAttachDetach(t *testing.T, testcase *testCase) {
 
 	// clear Applications table
 	// FIXME: Temporary solution. They should be cleared by pfcpiface, see SDFAB-960
-	p4rtClient, _ := providers.ConnectP4rt("127.0.0.1:50001", p4_v1.Uint128{High: 2, Low: 1})
+	p4rtClient, _ := providers.ConnectP4rt("127.0.0.1:50001", TimeBasedElectionId())
 	defer func() {
 		providers.DisconnectP4rt()
 		// give pfcpiface time to become master controller again


### PR DESCRIPTION
This PR replaces the hardcoded election IDs with time based ones in both the PFCP agent P4RT driver and test code. Hopefully this addresses the spurious election ID errors we observe in CI and locally. 

For reference:
https://github.com/omec-project/upf-epc/pull/457
https://github.com/omec-project/upf-epc/pull/446