### PR TITLE
Find the right session QER

### DIFF
--- a/pfcpiface/session_qer.go
+++ b/pfcpiface/session_qer.go
@@ -118,6 +118,7 @@ func (s *PFCPSession) MarkSessionQer(qers []qer) {
 			if qer.ulMbr >= sessionMbr {
 				sessionIdx = idx
 				sessQerID = qer.qerID
+				sessionMbr = qer.ulMbr
 			}
 		}
 	}


### PR DESCRIPTION
Before, we were not updating the session MBR. By doing this, we were getting always the last QER in the list as session QER.